### PR TITLE
feat: 게시글 검색/페이지네이션/통계 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### env ###
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'me.paulschwarz:spring-dotenv:3.0.0'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/katecam/hyuswim/post/controller/PostController.java
+++ b/src/main/java/katecam/hyuswim/post/controller/PostController.java
@@ -2,17 +2,17 @@ package katecam.hyuswim.post.controller;
 
 import katecam.hyuswim.common.ApiResponse;
 import katecam.hyuswim.post.domain.PostCategory;
-import katecam.hyuswim.post.dto.PageResponse;
-import katecam.hyuswim.post.dto.PostListResponse;
-import katecam.hyuswim.post.dto.PostRequest;
-import katecam.hyuswim.post.dto.PostDetailResponse;
+import katecam.hyuswim.post.dto.*;
 import katecam.hyuswim.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -60,15 +60,10 @@ public class PostController {
 
     @GetMapping("/search")
     public ApiResponse<PageResponse<PostListResponse>> searchPosts(
-            @RequestParam(required = false) PostCategory category,
-            @RequestParam(required = false) String keyword,
-            @PageableDefault(
-                    sort = "createdAt",
-                    direction = Sort.Direction.DESC,
-                    size = 10)
-            Pageable pageable
+            PostSearchRequest request,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC, size = 10) Pageable pageable
     ) {
-        return ApiResponse.success(postService.searchPosts(category, keyword, pageable));
+        return ApiResponse.success(postService.searchPosts(request, pageable));
     }
 
     @PatchMapping("/{id}")

--- a/src/main/java/katecam/hyuswim/post/controller/PostController.java
+++ b/src/main/java/katecam/hyuswim/post/controller/PostController.java
@@ -60,14 +60,15 @@ public class PostController {
 
     @GetMapping("/search")
     public ApiResponse<PageResponse<PostListResponse>> searchPosts(
-            @RequestParam String keyword,
+            @RequestParam(required = false) PostCategory category,
+            @RequestParam(required = false) String keyword,
             @PageableDefault(
                     sort = "createdAt",
                     direction = Sort.Direction.DESC,
                     size = 10)
             Pageable pageable
     ) {
-        return ApiResponse.success(postService.searchPosts(keyword, pageable));
+        return ApiResponse.success(postService.searchPosts(category, keyword, pageable));
     }
 
     @PatchMapping("/{id}")

--- a/src/main/java/katecam/hyuswim/post/controller/PostController.java
+++ b/src/main/java/katecam/hyuswim/post/controller/PostController.java
@@ -43,6 +43,11 @@ public class PostController {
         return ApiResponse.success(response);
     }
 
+    @GetMapping("/search")
+    public ApiResponse<List<PostListResponse>> searchPosts(@RequestParam String keyword) {
+        return ApiResponse.success(postService.searchPosts(keyword));
+    }
+
     @PatchMapping("/{id}")
     public ApiResponse<PostDetailResponse> updatePost(@PathVariable Long id,
                                                       @RequestBody PostRequest request,

--- a/src/main/java/katecam/hyuswim/post/controller/PostController.java
+++ b/src/main/java/katecam/hyuswim/post/controller/PostController.java
@@ -1,13 +1,16 @@
 package katecam.hyuswim.post.controller;
 
 import katecam.hyuswim.common.ApiResponse;
-import katecam.hyuswim.post.domain.Post;
 import katecam.hyuswim.post.domain.PostCategory;
+import katecam.hyuswim.post.dto.PageResponse;
 import katecam.hyuswim.post.dto.PostListResponse;
 import katecam.hyuswim.post.dto.PostRequest;
 import katecam.hyuswim.post.dto.PostDetailResponse;
 import katecam.hyuswim.post.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,9 +30,14 @@ public class PostController {
     }
 
     @GetMapping
-    public ApiResponse<List<PostListResponse>> getPosts() {
-        List<PostListResponse> response = postService.getPosts();
-        return ApiResponse.success(response);
+    public ApiResponse<PageResponse<PostListResponse>> getPosts(
+            @PageableDefault(
+                    sort = "createdAt",
+                    direction = Sort.Direction.DESC,
+                    size = 10
+            ) Pageable pageable
+    ) {
+        return ApiResponse.success(postService.getPosts(pageable));
     }
 
     @GetMapping("/category/{category}")

--- a/src/main/java/katecam/hyuswim/post/controller/PostController.java
+++ b/src/main/java/katecam/hyuswim/post/controller/PostController.java
@@ -8,12 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/posts")

--- a/src/main/java/katecam/hyuswim/post/controller/PostController.java
+++ b/src/main/java/katecam/hyuswim/post/controller/PostController.java
@@ -59,8 +59,15 @@ public class PostController {
     }
 
     @GetMapping("/search")
-    public ApiResponse<List<PostListResponse>> searchPosts(@RequestParam String keyword) {
-        return ApiResponse.success(postService.searchPosts(keyword));
+    public ApiResponse<PageResponse<PostListResponse>> searchPosts(
+            @RequestParam String keyword,
+            @PageableDefault(
+                    sort = "createdAt",
+                    direction = Sort.Direction.DESC,
+                    size = 10)
+            Pageable pageable
+    ) {
+        return ApiResponse.success(postService.searchPosts(keyword, pageable));
     }
 
     @PatchMapping("/{id}")

--- a/src/main/java/katecam/hyuswim/post/controller/PostController.java
+++ b/src/main/java/katecam/hyuswim/post/controller/PostController.java
@@ -41,8 +41,15 @@ public class PostController {
     }
 
     @GetMapping("/category/{category}")
-    public ApiResponse<List<PostListResponse>> getPostsByCategory(@PathVariable PostCategory category) {
-        return ApiResponse.success(postService.getPostsByCategory(category));
+    public ApiResponse<PageResponse<PostListResponse>> getPostsByCategory(
+            @PathVariable PostCategory category,
+            @PageableDefault(
+                    sort = "createdAt",
+                    direction = Sort.Direction.DESC,
+                    size = 10)
+            Pageable pageable
+    ) {
+        return ApiResponse.success(postService.getPostsByCategory(category, pageable));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/katecam/hyuswim/post/controller/PostController.java
+++ b/src/main/java/katecam/hyuswim/post/controller/PostController.java
@@ -1,6 +1,8 @@
 package katecam.hyuswim.post.controller;
 
 import katecam.hyuswim.common.ApiResponse;
+import katecam.hyuswim.post.domain.Post;
+import katecam.hyuswim.post.domain.PostCategory;
 import katecam.hyuswim.post.dto.PostListResponse;
 import katecam.hyuswim.post.dto.PostRequest;
 import katecam.hyuswim.post.dto.PostDetailResponse;
@@ -28,6 +30,11 @@ public class PostController {
     public ApiResponse<List<PostListResponse>> getPosts() {
         List<PostListResponse> response = postService.getPosts();
         return ApiResponse.success(response);
+    }
+
+    @GetMapping("/category/{category}")
+    public ApiResponse<List<PostListResponse>> getPostsByCategory(@PathVariable PostCategory category) {
+        return ApiResponse.success(postService.getPostsByCategory(category));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/katecam/hyuswim/post/controller/PostStatController.java
+++ b/src/main/java/katecam/hyuswim/post/controller/PostStatController.java
@@ -1,0 +1,22 @@
+package katecam.hyuswim.post.controller;
+
+import katecam.hyuswim.common.ApiResponse;
+import katecam.hyuswim.post.dto.PostStatsResponse;
+import katecam.hyuswim.post.service.PostStatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PostStatController {
+
+    private final PostStatService postStatService;
+
+    @GetMapping("/stats")
+    public ApiResponse<PostStatsResponse> getPostStats() {
+        return ApiResponse.success(postStatService.getPostStats());
+    }
+}

--- a/src/main/java/katecam/hyuswim/post/dto/PageResponse.java
+++ b/src/main/java/katecam/hyuswim/post/dto/PageResponse.java
@@ -1,0 +1,25 @@
+package katecam.hyuswim.post.dto;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class PageResponse<T> {
+    private final List<T> content;
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+    private final boolean last;
+
+    public PageResponse(Page<T> page) {
+        this.content = page.getContent();
+        this.page = page.getNumber();
+        this.size = page.getSize();
+        this.totalElements = page.getTotalElements();
+        this.totalPages = page.getTotalPages();
+        this.last = page.isLast();
+    }
+}

--- a/src/main/java/katecam/hyuswim/post/dto/PostSearchRequest.java
+++ b/src/main/java/katecam/hyuswim/post/dto/PostSearchRequest.java
@@ -1,0 +1,19 @@
+package katecam.hyuswim.post.dto;
+
+import katecam.hyuswim.post.domain.PostCategory;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+public class PostSearchRequest {
+    private PostCategory category;
+    private String keyword;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate startDate;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate endDate;
+}

--- a/src/main/java/katecam/hyuswim/post/dto/PostStatsResponse.java
+++ b/src/main/java/katecam/hyuswim/post/dto/PostStatsResponse.java
@@ -1,0 +1,13 @@
+package katecam.hyuswim.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostStatsResponse {
+    private long totalCount;
+    private long weekCount;
+    private long todayCount;
+}
+

--- a/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
+++ b/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
@@ -21,7 +21,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p FROM Post p " +
             "WHERE p.isDeleted = false " +
-            "AND (:category IS NULL OR p.category = :category) " +
+            "AND (:category IS NULL OR p.postCategory = :category) " +
             "AND (:keyword IS NULL OR p.title LIKE CONCAT('%', :keyword, '%') OR p.content LIKE CONCAT('%', :keyword, '%')) " +
             "AND (:startDate IS NULL OR p.createdAt >= :startDate) " +
             "AND (:endDate IS NULL OR p.createdAt <= :endDate)")

--- a/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
+++ b/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
@@ -14,8 +14,11 @@ import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByIsDeletedFalse(Pageable pageable);
+
     Optional<Post> findByIdAndIsDeletedFalse(Long id);
+
     Page<Post> findByCategoryAndIsDeletedFalse(PostCategory category, Pageable pageable);
+
     @Query("SELECT p FROM Post p WHERE p.isDeleted = false AND (:category IS NULL OR p.category = :category) AND (:keyword IS NULL OR p.title LIKE %:keyword% OR p.content LIKE %:keyword%) AND (:startDate IS NULL OR p.createdAt >= :startDate) AND (:endDate IS NULL OR p.createdAt <= :endDate)")
     Page<Post> searchByCategoryAndKeywordAndPeriod(
             @Param("category") PostCategory category,
@@ -24,4 +27,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             @Param("endDate") LocalDateTime endDate,
             Pageable pageable
     );
+
+    long countByIsDeletedFalse();
+
+    long countByIsDeletedFalseAndCreatedAtBetween(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
+++ b/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
@@ -16,5 +16,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByIdAndIsDeletedFalse(Long id);
     Page<Post> findByCategoryAndIsDeletedFalse(PostCategory category, Pageable pageable);
     @Query("SELECT p FROM Post p WHERE p.isDeleted = false AND (p.title LIKE %:keyword% OR p.content LIKE %:keyword%)")
-    List<Post> searchByKeyword(@Param("keyword") String keyword);
+    Page<Post> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
+++ b/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByIsDeletedFalse(Pageable pageable);
     Optional<Post> findByIdAndIsDeletedFalse(Long id);
-    List<Post> findByCategoryAndIsDeletedFalse(PostCategory category);
+    Page<Post> findByCategoryAndIsDeletedFalse(PostCategory category, Pageable pageable);
     @Query("SELECT p FROM Post p WHERE p.isDeleted = false AND (p.title LIKE %:keyword% OR p.content LIKE %:keyword%)")
     List<Post> searchByKeyword(@Param("keyword") String keyword);
 }

--- a/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
+++ b/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
@@ -2,6 +2,8 @@ package katecam.hyuswim.post.repository;
 
 import katecam.hyuswim.post.domain.Post;
 import katecam.hyuswim.post.domain.PostCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-    List<Post> findAllByIsDeletedFalse();
+    Page<Post> findAllByIsDeletedFalse(Pageable pageable);
     Optional<Post> findByIdAndIsDeletedFalse(Long id);
     List<Post> findByCategoryAndIsDeletedFalse(PostCategory category);
     @Query("SELECT p FROM Post p WHERE p.isDeleted = false AND (p.title LIKE %:keyword% OR p.content LIKE %:keyword%)")

--- a/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
+++ b/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
@@ -19,7 +19,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findByCategoryAndIsDeletedFalse(PostCategory category, Pageable pageable);
 
-    @Query("SELECT p FROM Post p WHERE p.isDeleted = false AND (:category IS NULL OR p.category = :category) AND (:keyword IS NULL OR p.title LIKE %:keyword% OR p.content LIKE %:keyword%) AND (:startDate IS NULL OR p.createdAt >= :startDate) AND (:endDate IS NULL OR p.createdAt <= :endDate)")
+    @Query("SELECT p FROM Post p " +
+            "WHERE p.isDeleted = false " +
+            "AND (:category IS NULL OR p.category = :category) " +
+            "AND (:keyword IS NULL OR p.title LIKE CONCAT('%', :keyword, '%') OR p.content LIKE CONCAT('%', :keyword, '%')) " +
+            "AND (:startDate IS NULL OR p.createdAt >= :startDate) " +
+            "AND (:endDate IS NULL OR p.createdAt <= :endDate)")
     Page<Post> searchByCategoryAndKeywordAndPeriod(
             @Param("category") PostCategory category,
             @Param("keyword") String keyword,

--- a/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
+++ b/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,10 +16,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByIsDeletedFalse(Pageable pageable);
     Optional<Post> findByIdAndIsDeletedFalse(Long id);
     Page<Post> findByCategoryAndIsDeletedFalse(PostCategory category, Pageable pageable);
-    @Query("SELECT p FROM Post p WHERE p.isDeleted = false AND (:category IS NULL OR p.category = :category) AND (:keyword IS NULL OR p.title LIKE %:keyword% OR p.content LIKE %:keyword%)")
-    Page<Post> searchByCategoryAndKeyword(
+    @Query("SELECT p FROM Post p WHERE p.isDeleted = false AND (:category IS NULL OR p.category = :category) AND (:keyword IS NULL OR p.title LIKE %:keyword% OR p.content LIKE %:keyword%) AND (:startDate IS NULL OR p.createdAt >= :startDate) AND (:endDate IS NULL OR p.createdAt <= :endDate)")
+    Page<Post> searchByCategoryAndKeywordAndPeriod(
             @Param("category") PostCategory category,
             @Param("keyword") String keyword,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
             Pageable pageable
     );
 }

--- a/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
+++ b/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
@@ -17,7 +17,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Optional<Post> findByIdAndIsDeletedFalse(Long id);
 
-    Page<Post> findByCategoryAndIsDeletedFalse(PostCategory category, Pageable pageable);
+    Page<Post> findByPostCategoryAndIsDeletedFalse(PostCategory postCategory, Pageable pageable);
 
     @Query("SELECT p FROM Post p " +
             "WHERE p.isDeleted = false " +

--- a/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
+++ b/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
@@ -15,6 +15,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByIsDeletedFalse(Pageable pageable);
     Optional<Post> findByIdAndIsDeletedFalse(Long id);
     Page<Post> findByCategoryAndIsDeletedFalse(PostCategory category, Pageable pageable);
-    @Query("SELECT p FROM Post p WHERE p.isDeleted = false AND (p.title LIKE %:keyword% OR p.content LIKE %:keyword%)")
-    Page<Post> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+    @Query("SELECT p FROM Post p WHERE p.isDeleted = false AND (:category IS NULL OR p.category = :category) AND (:keyword IS NULL OR p.title LIKE %:keyword% OR p.content LIKE %:keyword%)")
+    Page<Post> searchByCategoryAndKeyword(
+            @Param("category") PostCategory category,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
+++ b/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package katecam.hyuswim.post.repository;
 
 import katecam.hyuswim.post.domain.Post;
+import katecam.hyuswim.post.domain.PostCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,4 +10,5 @@ import java.util.Optional;
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByIsDeletedFalse();
     Optional<Post> findByIdAndIsDeletedFalse(Long id);
+    List<Post> findByCategoryAndIsDeletedFalse(PostCategory category);
 }

--- a/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
+++ b/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
@@ -3,6 +3,8 @@ package katecam.hyuswim.post.repository;
 import katecam.hyuswim.post.domain.Post;
 import katecam.hyuswim.post.domain.PostCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +13,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByIsDeletedFalse();
     Optional<Post> findByIdAndIsDeletedFalse(Long id);
     List<Post> findByCategoryAndIsDeletedFalse(PostCategory category);
+    @Query("SELECT p FROM Post p WHERE p.isDeleted = false AND (p.title LIKE %:keyword% OR p.content LIKE %:keyword%)")
+    List<Post> searchByKeyword(@Param("keyword") String keyword);
 }

--- a/src/main/java/katecam/hyuswim/post/service/PostService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostService.java
@@ -1,6 +1,7 @@
 package katecam.hyuswim.post.service;
 
 import katecam.hyuswim.post.domain.Post;
+import katecam.hyuswim.post.domain.PostCategory;
 import katecam.hyuswim.post.dto.PostListResponse;
 import katecam.hyuswim.post.repository.PostRepository;
 import katecam.hyuswim.post.dto.PostRequest;
@@ -41,6 +42,12 @@ public class PostService {
     public List<PostListResponse> getPosts() {
         return postRepository.findAllByIsDeletedFalse().stream()
                 .filter(post -> !post.getIsDeleted())
+                .map(PostListResponse::from)
+                .toList();
+    }
+
+    public List<PostListResponse> getPostsByCategory(PostCategory category) {
+        return postRepository.findByCategoryAndIsDeletedFalse(category).stream()
                 .map(PostListResponse::from)
                 .toList();
     }

--- a/src/main/java/katecam/hyuswim/post/service/PostService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostService.java
@@ -2,6 +2,7 @@ package katecam.hyuswim.post.service;
 
 import katecam.hyuswim.post.domain.Post;
 import katecam.hyuswim.post.domain.PostCategory;
+import katecam.hyuswim.post.dto.PageResponse;
 import katecam.hyuswim.post.dto.PostListResponse;
 import katecam.hyuswim.post.repository.PostRepository;
 import katecam.hyuswim.post.dto.PostRequest;
@@ -9,6 +10,7 @@ import katecam.hyuswim.post.dto.PostDetailResponse;
 import katecam.hyuswim.user.User;
 import katecam.hyuswim.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,11 +41,11 @@ public class PostService {
         return PostDetailResponse.from(saved);
     }
 
-    public List<PostListResponse> getPosts() {
-        return postRepository.findAllByIsDeletedFalse().stream()
-                .filter(post -> !post.getIsDeleted())
-                .map(PostListResponse::from)
-                .toList();
+    public PageResponse<PostListResponse> getPosts(Pageable pageable) {
+        return new PageResponse<>(
+                postRepository.findAllByIsDeletedFalse(pageable)
+                        .map(PostListResponse::from)
+        );
     }
 
     public List<PostListResponse> getPostsByCategory(PostCategory category) {

--- a/src/main/java/katecam/hyuswim/post/service/PostService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostService.java
@@ -61,12 +61,11 @@ public class PostService {
         return PostDetailResponse.from(post);
     }
 
-    public List<PostListResponse> searchPosts(String keyword) {
-        return postRepository
-                .searchByKeyword(keyword)
-                .stream()
-                .map(PostListResponse::from)
-                .toList();
+    public PageResponse<PostListResponse> searchPosts(String keyword, Pageable pageable) {
+        return new PageResponse<>(
+                postRepository.searchByKeyword(keyword, pageable)
+                        .map(PostListResponse::from)
+        );
     }
 
     @Transactional

--- a/src/main/java/katecam/hyuswim/post/service/PostService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostService.java
@@ -2,11 +2,8 @@ package katecam.hyuswim.post.service;
 
 import katecam.hyuswim.post.domain.Post;
 import katecam.hyuswim.post.domain.PostCategory;
-import katecam.hyuswim.post.dto.PageResponse;
-import katecam.hyuswim.post.dto.PostListResponse;
+import katecam.hyuswim.post.dto.*;
 import katecam.hyuswim.post.repository.PostRepository;
-import katecam.hyuswim.post.dto.PostRequest;
-import katecam.hyuswim.post.dto.PostDetailResponse;
 import katecam.hyuswim.user.User;
 import katecam.hyuswim.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +11,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -61,10 +60,18 @@ public class PostService {
         return PostDetailResponse.from(post);
     }
 
-    public PageResponse<PostListResponse> searchPosts(PostCategory category, String keyword, Pageable pageable) {
+    public PageResponse<PostListResponse> searchPosts(PostSearchRequest request, Pageable pageable) {
+        LocalDateTime startDateTime = (request.getStartDate() != null) ? request.getStartDate().atStartOfDay() : null;
+        LocalDateTime endDateTime = (request.getEndDate() != null) ? request.getEndDate().plusDays(1).atStartOfDay().minusNanos(1) : null;
+
         return new PageResponse<>(
-                postRepository.searchByCategoryAndKeyword(category, keyword, pageable)
-                        .map(PostListResponse::from)
+                postRepository.searchByCategoryAndKeywordAndPeriod(
+                        request.getCategory(),
+                        request.getKeyword(),
+                        startDateTime,
+                        endDateTime,
+                        pageable
+                ).map(PostListResponse::from)
         );
     }
 

--- a/src/main/java/katecam/hyuswim/post/service/PostService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostService.java
@@ -11,9 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/katecam/hyuswim/post/service/PostService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostService.java
@@ -61,9 +61,9 @@ public class PostService {
         return PostDetailResponse.from(post);
     }
 
-    public PageResponse<PostListResponse> searchPosts(String keyword, Pageable pageable) {
+    public PageResponse<PostListResponse> searchPosts(PostCategory category, String keyword, Pageable pageable) {
         return new PageResponse<>(
-                postRepository.searchByKeyword(keyword, pageable)
+                postRepository.searchByCategoryAndKeyword(category, keyword, pageable)
                         .map(PostListResponse::from)
         );
     }

--- a/src/main/java/katecam/hyuswim/post/service/PostService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostService.java
@@ -58,6 +58,14 @@ public class PostService {
         return PostDetailResponse.from(post);
     }
 
+    public List<PostListResponse> searchPosts(String keyword) {
+        return postRepository
+                .searchByKeyword(keyword)
+                .stream()
+                .map(PostListResponse::from)
+                .toList();
+    }
+
     @Transactional
     public PostDetailResponse updatePost(Long id, PostRequest request, Long userId) {
         Post post = postRepository.findById(id)

--- a/src/main/java/katecam/hyuswim/post/service/PostService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostService.java
@@ -47,7 +47,7 @@ public class PostService {
 
     public PageResponse<PostListResponse> getPostsByCategory(PostCategory category, Pageable pageable) {
         return new PageResponse<>(
-                postRepository.findByCategoryAndIsDeletedFalse(category, pageable)
+                postRepository.findByPostCategoryAndIsDeletedFalse(category, pageable)
                         .map(PostListResponse::from)
         );
     }

--- a/src/main/java/katecam/hyuswim/post/service/PostService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostService.java
@@ -48,10 +48,11 @@ public class PostService {
         );
     }
 
-    public List<PostListResponse> getPostsByCategory(PostCategory category) {
-        return postRepository.findByCategoryAndIsDeletedFalse(category).stream()
-                .map(PostListResponse::from)
-                .toList();
+    public PageResponse<PostListResponse> getPostsByCategory(PostCategory category, Pageable pageable) {
+        return new PageResponse<>(
+                postRepository.findByCategoryAndIsDeletedFalse(category, pageable)
+                        .map(PostListResponse::from)
+        );
     }
 
     public PostDetailResponse getPost(Long id) {

--- a/src/main/java/katecam/hyuswim/post/service/PostService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostService.java
@@ -39,7 +39,7 @@ public class PostService {
     }
 
     public List<PostListResponse> getPosts() {
-        return postRepository.findAll().stream()
+        return postRepository.findAllByIsDeletedFalse().stream()
                 .filter(post -> !post.getIsDeleted())
                 .map(PostListResponse::from)
                 .toList();

--- a/src/main/java/katecam/hyuswim/post/service/PostStatService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostStatService.java
@@ -1,0 +1,31 @@
+package katecam.hyuswim.post.service;
+
+import katecam.hyuswim.post.dto.PostStatsResponse;
+import katecam.hyuswim.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PostStatService {
+
+    private final PostRepository postRepository;
+
+    public PostStatsResponse getPostStats() {
+        LocalDateTime startOfToday = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfToday = startOfToday.plusDays(1).minusNanos(1);
+
+        LocalDateTime startOfWeek = LocalDate.now().with(DayOfWeek.MONDAY).atStartOfDay();
+        LocalDateTime endOfWeek = startOfWeek.plusWeeks(1).minusNanos(1);
+
+        long totalCount = postRepository.countByIsDeletedFalse();
+        long todayCount = postRepository.countByIsDeletedFalseAndCreatedAtBetween(startOfToday, endOfToday);
+        long weekCount = postRepository.countByIsDeletedFalseAndCreatedAtBetween(startOfWeek, endOfWeek);
+
+        return new PostStatsResponse(totalCount, weekCount, todayCount);
+    }
+}


### PR DESCRIPTION
## 작업 개요
- 게시글 검색/통계 API 구현
- 게시글 조회 API 개선
- spring-dotenv 기반 환경 변수 관리 도입

## 상세 내용
- 게시글 검색 API (GET /api/posts/search?keyword=)
  - 제목 + 내용 키워드 검색
  - 카테고리별 검색 (?category=FREE)
  - 기간 필터 (?startDate=2025-08-01&endDate=2025-09-05)
  - 페이지네이션 및 정렬 옵션 지원 (createdAt, viewCount, likeCount)
- 게시글 카테고리별 조회 API (GET /api/posts/category/{category})
  - 페이지네이션 및 정렬 옵션 지원
- 게시글 통계 API (GET /api/posts/stats)
  - 전체 게시글 수
  - 이번 주 작성된 게시글 수
  - 오늘 작성된 게시글 수
- 게시글 조회 API 개선
  - 전체 조회 시 페이지네이션 적용
  - 삭제된 글도 검색되던 오류 해결
- 환경 변수 관리
  - spring-dotenv 라이브러리 도입 및 .env 기반 환경 변수 설정
  - .gitignore에 .env 추가하여 버전 관리 제외

## 관련 이슈
- Closes #17 

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 리뷰어가 이해할 수 있도록 설명 작성
- [x] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 검색/통계 API 쿼리 성능 및 페이징 처리 적절성
