### PR TITLE
chore : 이슈 템플릿 개선 (Bug/Feature/Task 타입 자동 지정)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -2,7 +2,7 @@
 name: "Bug"
 about: "버그 리포트 이슈"
 title: "[Bug] "
-labels: ["bug"]
+type: Bug
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -2,7 +2,7 @@
 name: "Chore"
 about: "설정 변경, 리팩토링, 문서 작성 등 작업"
 title: "[Chore] "
-labels: ["chore"]
+type: Task
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -2,7 +2,7 @@
 name: "Feature"
 about: "새로운 기능 추가/개발 작업 이슈"
 title: "[Feature] "
-labels: ["feature"]
+type: Feature
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -2,7 +2,7 @@
 name: "Refactor"
 about: "코드 리팩토링 작업 이슈"
 title: "[Refactor] "
-labels: ["refactor"]
+type: Task
 assignees: ""
 ---
 


### PR DESCRIPTION
## 작업 개요
- GitHub 이슈 템플릿을 라벨 기반에서 타입 자동 지정 방식으로 변경

## 상세 내용
- 기존 `labels` 자동 지정 제거
- GitHub 기본 제공 `type` 필드(Bug / Feature / Task) 자동 지정 추가

## 관련 이슈
- Closes #37

## 테스트 방법
- [x] 새로운 이슈 생성 시 타입이 자동으로 지정되는지 확인

## 체크리스트
- [x] 빌드 및 테스트 통과 (템플릿 정상 인식 확인)
- [x] 코드 컨벤션 준수
- [x] 리뷰어가 이해할 수 있도록 설명 작성
- [x] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- Bug / Feature / Task 세 가지 템플릿이 일관성 있게 동작하는지
- 타입 기반 관리 방식이 팀 컨벤션과 맞는지
