### PR TITLE
feat : 게시글 좋아요 기능 구현

### DIFF
--- a/src/main/java/katecam/hyuswim/common/error/ErrorCode.java
+++ b/src/main/java/katecam/hyuswim/common/error/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
   COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
   POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "작성자만 게시글을 수정/삭제할 수 있습니다."),
   COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "작성자만 댓글을 수정/삭제할 수 있습니다."),
+  LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요가 존재하지 않습니다."),
   ALREADY_LIKED_POST(HttpStatus.CONFLICT, "이미 좋아요를 누른 게시글입니다."),
   REPORT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "기타 사유 선택 시 내용은 필수입니다."),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 오류가 발생했습니다.");

--- a/src/main/java/katecam/hyuswim/common/error/ErrorCode.java
+++ b/src/main/java/katecam/hyuswim/common/error/ErrorCode.java
@@ -14,7 +14,6 @@ public enum ErrorCode {
   POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "작성자만 게시글을 수정/삭제할 수 있습니다."),
   COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "작성자만 댓글을 수정/삭제할 수 있습니다."),
   LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요가 존재하지 않습니다."),
-  ALREADY_LIKED_POST(HttpStatus.CONFLICT, "이미 좋아요를 누른 게시글입니다."),
   REPORT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "기타 사유 선택 시 내용은 필수입니다."),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 오류가 발생했습니다.");
 

--- a/src/main/java/katecam/hyuswim/common/error/ErrorCode.java
+++ b/src/main/java/katecam/hyuswim/common/error/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
   COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
   POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "작성자만 게시글을 수정/삭제할 수 있습니다."),
   COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "작성자만 댓글을 수정/삭제할 수 있습니다."),
+  ALREADY_LIKED_POST(HttpStatus.CONFLICT, "이미 좋아요를 누른 게시글입니다."),
   REPORT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "기타 사유 선택 시 내용은 필수입니다."),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 오류가 발생했습니다.");
 

--- a/src/main/java/katecam/hyuswim/like/controller/PostLikeController.java
+++ b/src/main/java/katecam/hyuswim/like/controller/PostLikeController.java
@@ -18,4 +18,10 @@ public class PostLikeController {
     postLikeService.addLike(postId, userId);
     return ResponseEntity.ok().build();
   }
+
+  @DeleteMapping("/posts/{postId}/likes")
+  public ResponseEntity<Void> deleteLike(@PathVariable Long postId, @RequestParam Long userId) {
+    postLikeService.deleteLike(postId, userId);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/katecam/hyuswim/like/controller/PostLikeController.java
+++ b/src/main/java/katecam/hyuswim/like/controller/PostLikeController.java
@@ -1,0 +1,21 @@
+package katecam.hyuswim.like.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import katecam.hyuswim.like.service.PostLikeService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class PostLikeController {
+
+  private final PostLikeService postLikeService;
+
+  @PostMapping("/posts/{postId}/likes")
+  public ResponseEntity<Void> addLike(@PathVariable Long postId, @RequestParam Long userId) {
+    postLikeService.addLike(postId, userId);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/katecam/hyuswim/like/domain/PostLike.java
+++ b/src/main/java/katecam/hyuswim/like/domain/PostLike.java
@@ -1,4 +1,4 @@
-package katecam.hyuswim.like;
+package katecam.hyuswim.like.domain;
 
 import java.time.LocalDateTime;
 
@@ -8,24 +8,36 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import jakarta.persistence.*;
 import katecam.hyuswim.post.domain.Post;
 import katecam.hyuswim.user.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-public class Like {
+@Table(
+    name = "post_likes",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"post_id", "user_id"}))
+@Getter
+@NoArgsConstructor
+public class PostLike {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne
-  @JoinColumn(name = "board_id")
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "post_id", nullable = false)
   private Post post;
 
-  @ManyToOne
-  @JoinColumn(name = "user_id")
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
   @CreatedDate
   @Column(name = "created_at", updatable = false)
   private LocalDateTime createdAt;
+
+  public PostLike(Post post, User user) {
+    this.post = post;
+    this.user = user;
+  }
 }

--- a/src/main/java/katecam/hyuswim/like/repository/PostLikeRepository.java
+++ b/src/main/java/katecam/hyuswim/like/repository/PostLikeRepository.java
@@ -1,9 +1,13 @@
 package katecam.hyuswim.like.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import katecam.hyuswim.like.domain.PostLike;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+  Optional<PostLike> findByPostIdAndUserId(Long postId, Long userId);
+
   boolean existsByPostIdAndUserId(Long postId, Long uesrId);
 }

--- a/src/main/java/katecam/hyuswim/like/repository/PostLikeRepository.java
+++ b/src/main/java/katecam/hyuswim/like/repository/PostLikeRepository.java
@@ -1,0 +1,9 @@
+package katecam.hyuswim.like.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import katecam.hyuswim.like.domain.PostLike;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+  boolean existsByPostIdAndUserId(Long postId, Long uesrId);
+}

--- a/src/main/java/katecam/hyuswim/like/service/PostLikeService.java
+++ b/src/main/java/katecam/hyuswim/like/service/PostLikeService.java
@@ -1,0 +1,41 @@
+package katecam.hyuswim.like.service;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.transaction.Transactional;
+import katecam.hyuswim.common.error.CustomException;
+import katecam.hyuswim.common.error.ErrorCode;
+import katecam.hyuswim.like.domain.PostLike;
+import katecam.hyuswim.like.repository.PostLikeRepository;
+import katecam.hyuswim.post.domain.Post;
+import katecam.hyuswim.post.repository.PostRepository;
+import katecam.hyuswim.user.User;
+import katecam.hyuswim.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PostLikeService {
+
+  private final PostLikeRepository postLikeRepository;
+  private final PostRepository postRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public void addLike(Long postId, Long userId) {
+    if (postLikeRepository.existsByPostIdAndUserId(postId, userId)) {
+      throw new CustomException(ErrorCode.ALREADY_LIKED_POST);
+    }
+
+    Post post =
+        postRepository
+            .findById(postId)
+            .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+    postLikeRepository.save(new PostLike(post, user));
+  }
+}

--- a/src/main/java/katecam/hyuswim/like/service/PostLikeService.java
+++ b/src/main/java/katecam/hyuswim/like/service/PostLikeService.java
@@ -38,4 +38,14 @@ public class PostLikeService {
 
     postLikeRepository.save(new PostLike(post, user));
   }
+
+  @Transactional
+  public void deleteLike(Long postId, Long userId) {
+    PostLike postLike =
+        postLikeRepository
+            .findByPostIdAndUserId(postId, userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.LIKE_NOT_FOUND));
+
+    postLikeRepository.delete(postLike);
+  }
 }

--- a/src/main/java/katecam/hyuswim/like/service/PostLikeService.java
+++ b/src/main/java/katecam/hyuswim/like/service/PostLikeService.java
@@ -23,9 +23,6 @@ public class PostLikeService {
 
   @Transactional
   public void addLike(Long postId, Long userId) {
-    if (postLikeRepository.existsByPostIdAndUserId(postId, userId)) {
-      throw new CustomException(ErrorCode.ALREADY_LIKED_POST);
-    }
 
     Post post =
         postRepository

--- a/src/main/java/katecam/hyuswim/post/domain/Post.java
+++ b/src/main/java/katecam/hyuswim/post/domain/Post.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.*;
 import katecam.hyuswim.comment.domain.Comment;
-import katecam.hyuswim.like.Like;
+import katecam.hyuswim.like.domain.PostLike;
 import katecam.hyuswim.user.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,7 +29,7 @@ public class Post {
   private User user;
 
   @OneToMany(mappedBy = "post")
-  private List<Like> likes;
+  private List<PostLike> postLikes;
 
   @OneToMany(mappedBy = "post")
   private List<Comment> comments;

--- a/src/main/java/katecam/hyuswim/post/dto/PostDetailResponse.java
+++ b/src/main/java/katecam/hyuswim/post/dto/PostDetailResponse.java
@@ -37,7 +37,7 @@ public class PostDetailResponse {
         .isDeleted(entity.getIsDeleted())
         .isLiked(false)
         .viewCount(entity.getViewCount())
-        .likeCount((long) entity.getLikes().size())
+        .likeCount((long) entity.getPostLikes().size())
         .createdAt(entity.getCreatedAt())
         .updatedAt(entity.getUpdatedAt())
         .build();

--- a/src/main/java/katecam/hyuswim/post/dto/PostListResponse.java
+++ b/src/main/java/katecam/hyuswim/post/dto/PostListResponse.java
@@ -27,7 +27,7 @@ public class PostListResponse {
         .title(entity.getTitle())
         .content(entity.getContent())
         .author(entity.getUser().getEmail())
-        .likeCount((long) entity.getLikes().size())
+        .likeCount((long) entity.getPostLikes().size())
         .viewCount(entity.getViewCount())
         .createdAt(entity.getCreatedAt())
         .build();


### PR DESCRIPTION
## 작업 개요
- 게시글 좋아요 기능 추가

## 상세 내용
- 게시글 좋아요 API (POST /api/posts/{postId}/likes)
- 게시글 좋아요 취소 API (DELETE /api/posts/{postId}/likes)

- 등록 성공 → 200 OK
- 취소 성공 → 204 No Content
- 좋아요 취소하려 했는데 없으면 → 404 Not Found

- 도메인명
  **Like → PostLike로 변경**
  Like 시 db 예약어와 겹처서 에러 발생 가능성.
  추후 CommentLike로 확장 가능성 고려.

- resful 원칙에 맞는 기능 개발, 명확한 로깅과 분석 및 예외처리/권한관리, 추후 확장성을 고려하여 토글 방식이 아닌 등록/취소 api를 별도로 구현.

- 좋아요 등록 기능만 있는게 아니라서 불필요한 중복 좋아요 검증 기능 삭제

## 관련 이슈
- Closes #44 

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인
-> 로그인 완성 후 진행

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 리뷰어가 이해할 수 있도록 설명 작성
- [x] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 에러 코드 처리가 적절한지
- 좋아요 취소하려했는데 없는 상황 처리가 불필요한 것도 같은데 어떤지
- 오타나 실수가 없는지