### PR TITLE
[Fix] 시큐리티 설정에서 api,admin 분리

### DIFF
--- a/src/main/java/katecam/hyuswim/config/LocalSecurityConfig.java
+++ b/src/main/java/katecam/hyuswim/config/LocalSecurityConfig.java
@@ -49,33 +49,36 @@ public class LocalSecurityConfig {
   @Bean
   @Order(2)
   public SecurityFilterChain apiChain(HttpSecurity http) throws Exception {
-      http.securityMatcher("/api/**")
-              .authorizeHttpRequests(auth -> auth
-                      .requestMatchers("/api/user/signup", "/api/auth/login").permitAll()
-                      .requestMatchers(HttpMethod.GET,
-                              "/api/posts",
-                              "/api/posts/",
-                              "/api/posts/category/**",
-                              "/api/posts/search",
-                              "/api/posts/stats"
-                      ).permitAll()
-                      .anyRequest().authenticated()
-              )
-              .csrf(csrf -> csrf.disable())
-              .formLogin(form -> form.disable())
-              .httpBasic(Customizer.withDefaults())
-              .exceptionHandling(ex ->
-                      ex.authenticationEntryPoint((request, response, authException) -> {
-                          response.setContentType("application/json");
-                          response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                          response.getWriter().write("{\"error\":\"Unauthorized\"}");
-                      })
-              );
-      return http.build();
+    http.securityMatcher("/api/**")
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers("/api/user/signup", "/api/auth/login")
+                    .permitAll()
+                    .requestMatchers(
+                        HttpMethod.GET,
+                        "/api/posts",
+                        "/api/posts/",
+                        "/api/posts/category/**",
+                        "/api/posts/search",
+                        "/api/posts/stats")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
+        .csrf(csrf -> csrf.disable())
+        .formLogin(form -> form.disable())
+        .httpBasic(Customizer.withDefaults())
+        .exceptionHandling(
+            ex ->
+                ex.authenticationEntryPoint(
+                    (request, response, authException) -> {
+                      response.setContentType("application/json");
+                      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                      response.getWriter().write("{\"error\":\"Unauthorized\"}");
+                    }));
+    return http.build();
   }
 
-
-    // Admin 전용
+  // Admin 전용
   @Bean
   @Order(3)
   public SecurityFilterChain adminChain(HttpSecurity http) throws Exception {


### PR DESCRIPTION
## 작업 개요
- Spring Security 설정을 API 요청과 Admin 요청으로 분리
- API 요청 시 HTML 리다이렉트 대신 JSON 응답 반환

## 상세 내용
- /api/** 요청 전용 SecurityFilterChain 추가
- /api/user/signup, /api/auth/login은 permitAll 처리
- 나머지 요청은 인증 필요, 실패 시 JSON 401 Unauthorized 응답
- formLogin 비활성화, CSRF 비활성화
- /admin/** 요청 전용 SecurityFilterChain 추가
- 인증 실패 시 HTML 로그인 페이지 반환 (formLogin 유지)

## 관련 이슈
- Closes #66 

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 스타일 적용

## 리뷰 중점 사항
- 