### PR TITLE
[Feat] DB 서버 환경 구축

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -170,9 +170,11 @@ jobs:
 
             # 기동
             echo "Starting new application (${APP_JAR})... Logging to ${LOG_FILE_PATH}"
-            JAVA_OPTS=""
-            nohup java ${JAVA_OPTS} -jar "${APP_JAR}" \
-              --jwt.secret="${{ secrets.JWT_SECRET }}" > "${LOG_FILE_PATH}" 2>&1 &
+            JAVA_OPTS="--spring.datasource.url=jdbc:mysql://${{ secrets.EC2_HOST }}:3306/${{ secrets.DB_NAME }}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8 \
+                       --spring.datasource.username=${{ secrets.DB_USER }} \
+                       --spring.datasource.password=${{ secrets.DB_PASSWORD }} \
+                       --jwt.secret=${{ secrets.JWT_SECRET }}"
+            nohup java -jar "${APP_JAR}" $JAVA_OPTS > "${LOG_FILE_PATH}" 2>&1 &
 
             # 기동 확인
             echo "Verifying application startup..."
@@ -185,3 +187,4 @@ jobs:
               tail -n 120 "${LOG_FILE_PATH}" || true
               exit 1
             fi
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -174,7 +174,7 @@ jobs:
                        --spring.datasource.username=${{ secrets.DB_USER }} \
                        --spring.datasource.password=${{ secrets.DB_PASSWORD }} \
                        --jwt.secret=${{ secrets.JWT_SECRET }}"
-            nohup java -jar "${APP_JAR}" $JAVA_OPTS > "${LOG_FILE_PATH}" 2>&1 &
+            nohup java -Dspring.profiles.active=dev -jar "${APP_JAR}" $JAVA_OPTS > "${LOG_FILE_PATH}" 2>&1 &
 
             # 기동 확인
             echo "Verifying application startup..."

--- a/env.example
+++ b/env.example
@@ -1,0 +1,6 @@
+env.example
+JWT_SECRET=
+EC2_HOST=
+DB_USER=
+DB_PASSWORD=
+DB_NAME=

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${EC2_HOST}:3306/${DB_NAME}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## 작업 개요
- 배포 환경(dev)에서 EC2 MySQL을 사용할 수 있도록 프로파일 추가
- GitHub Secrets을 통해 DB 접속 정보 안전하게 주입하도록 수정

## 상세 내용
- `application-dev.yml` 생성 및 MySQL 연결 설정 추가
- 기존 `application.yml`은 공통 설정 유지, local/dev 분리
- GitHub Actions `deploy.yml`에 DB 관련 Secrets 전달 로직 추가
- JAR 실행 시 Secrets 기반으로 DB와 JWT Secret 주입되도록 설정

## 관련 이슈
- Closes #61 

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
