### PR TITLE
refactor : JWT 파싱 중복 제거 및 구조 개선 

### DIFF
--- a/src/main/java/katecam/hyuswim/auth/jwt/JwtTokenRequest.java
+++ b/src/main/java/katecam/hyuswim/auth/jwt/JwtTokenRequest.java
@@ -4,9 +4,8 @@ import katecam.hyuswim.user.UserRole;
 import lombok.*;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class JwtTokenRequest {
-
-  private Long userId;
-  private UserRole role;
+  private final Long userId;
+  private final UserRole role;
 }

--- a/src/main/java/katecam/hyuswim/auth/jwt/JwtTokenResponse.java
+++ b/src/main/java/katecam/hyuswim/auth/jwt/JwtTokenResponse.java
@@ -3,8 +3,7 @@ package katecam.hyuswim.auth.jwt;
 import lombok.*;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class JwtTokenResponse {
-
-  private String token;
+  private final String token;
 }

--- a/src/main/java/katecam/hyuswim/auth/jwt/JwtUtil.java
+++ b/src/main/java/katecam/hyuswim/auth/jwt/JwtUtil.java
@@ -2,13 +2,13 @@ package katecam.hyuswim.auth.jwt;
 
 import java.util.Date;
 
+import io.jsonwebtoken.*;
+import katecam.hyuswim.auth.principal.UserPrincipal;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import jakarta.annotation.PostConstruct;
 import katecam.hyuswim.user.UserRole;
 
@@ -20,38 +20,47 @@ public class JwtUtil {
 
   private JwtParser jwtParser;
 
-  private final long TOKEN_EXPIRATION_TIME_MS = 60 * 60 * 1000;
+  private final long TOKEN_EXPIRATION_TIME_MS = 60 * 60 * 1000; //1시간
 
   @PostConstruct
   public void init() {
     jwtParser = Jwts.parser().setSigningKey(secret).build();
   }
 
-  public Long extractUserId(String token) {
-    return Long.valueOf(jwtParser.parseClaimsJws(token).getBody().getSubject());
-  }
-
   public String generateToken(Long userId, UserRole role) {
-    long now = System.currentTimeMillis();
-    return Jwts.builder()
-        .setSubject(String.valueOf(userId))
-        .claim("role", role.name())
-        .setIssuedAt(new Date(now))
-        .setExpiration(new Date(now + TOKEN_EXPIRATION_TIME_MS))
-        .signWith(SignatureAlgorithm.HS256, secret)
-        .compact();
+      long now = System.currentTimeMillis();
+      return Jwts.builder()
+              .setSubject(String.valueOf(userId))
+              .claim("role", role.name())
+              .setIssuedAt(new Date(now))
+              .setExpiration(new Date(now + TOKEN_EXPIRATION_TIME_MS))
+              .signWith(SignatureAlgorithm.HS256, secret)
+              .compact();
   }
 
-  public Boolean validateToken(String token) {
-    try {
-      jwtParser.parseClaimsJws(token);
-      return !isTokenExpired(token);
-    } catch (JwtException e) {
-      return false;
+    public Claims getClaims(String token) {
+        try {
+            return jwtParser.parseClaimsJws(token).getBody();
+        } catch (JwtException e) {
+            return null;
+        }
     }
-  }
 
-  private Boolean isTokenExpired(String token) {
-    return jwtParser.parseClaimsJws(token).getBody().getExpiration().before(new Date());
-  }
+    public boolean isTokenExpired(Claims claims) {
+        return claims.getExpiration().before(new Date());
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = getClaims(token);
+        if (claims == null || isTokenExpired(claims)) return null;
+
+        Long userId = Long.valueOf(claims.getSubject());
+        UserRole role = UserRole.valueOf(claims.get("role", String.class));
+
+        UserPrincipal principal = new UserPrincipal(userId, role);
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, principal.getAuthorities()
+        );
+    }
+
 }

--- a/src/main/java/katecam/hyuswim/auth/jwt/JwtUtil.java
+++ b/src/main/java/katecam/hyuswim/auth/jwt/JwtUtil.java
@@ -20,7 +20,7 @@ public class JwtUtil {
 
   private JwtParser jwtParser;
 
-  private final long TOKEN_EXPIRATION_TIME_MS = 60 * 60 * 1000; //1시간
+  private static final long TOKEN_EXPIRATION_TIME_MS = 60 * 60 * 1000; //1시간
 
   @PostConstruct
   public void init() {

--- a/src/main/java/katecam/hyuswim/auth/principal/UserPrincipal.java
+++ b/src/main/java/katecam/hyuswim/auth/principal/UserPrincipal.java
@@ -3,6 +3,8 @@ package katecam.hyuswim.auth.principal;
 import java.util.Collection;
 import java.util.List;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -10,32 +12,25 @@ import org.springframework.security.core.userdetails.UserDetails;
 import katecam.hyuswim.user.User;
 import katecam.hyuswim.user.UserRole;
 
+@Getter
+@RequiredArgsConstructor
 public class UserPrincipal implements UserDetails {
-
-  private final User user;
-
-  public UserPrincipal(User user) {
-    this.user = user;
-  }
-
-  public User getUser() {
-    return user;
-  }
+    private final Long userId;
+    private final UserRole role;
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    UserRole role = user.getRole();
-    return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+      return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
   }
 
   @Override
   public String getPassword() {
-    return user.getPassword();
+        return null;
   }
 
   @Override
   public String getUsername() {
-    return String.valueOf(user.getId());
+      return String.valueOf(userId);
   }
 
   @Override

--- a/src/main/java/katecam/hyuswim/post/dto/PostDetailResponse.java
+++ b/src/main/java/katecam/hyuswim/post/dto/PostDetailResponse.java
@@ -35,7 +35,7 @@ public class PostDetailResponse {
         .postCategoryName(entity.getPostCategory().getDisplayName())
         .title(entity.getTitle())
         .content(entity.getContent())
-        .author(entity.getUser().getEmail())
+        .author(entity.getUser().getNickname())
         .isAnonymous(entity.getIsAnonymous())
         .isDeleted(entity.getIsDeleted())
         .isLiked(false)

--- a/src/main/java/katecam/hyuswim/post/dto/PostListResponse.java
+++ b/src/main/java/katecam/hyuswim/post/dto/PostListResponse.java
@@ -31,7 +31,7 @@ public class PostListResponse {
         .postCategory(entity.getPostCategory().name())
         .postCategoryName(entity.getPostCategory().getDisplayName())
         .content(entity.getContent())
-        .author(entity.getUser().getEmail())
+        .author(entity.getUser().getNickname())
         .likeCount((long) entity.getPostLikes().size())
         .commentCount((long) entity.getComments().size())
         .viewCount(entity.getViewCount())


### PR DESCRIPTION
## 작업 개요
- JWT 토큰 구조 및 유틸 개선
- 토큰에 사용자 role 클레임 추가

## 상세 내용
- JWT 파싱 로직 중복 제거 (Claims 1회 파싱 후 재사용)
- User 조회 최소화 (DB 접근 줄이고 JWT 자체 정보 활용)
- `TOKEN_EXPIRATION_TIME_MS`를 `static final`로 변경하고 주석 추가
- 불변 패턴 적용 (`final` + `@RequiredArgsConstructor`)
- JWT 토큰 생성 시 role 정보를 클레임에 포함하도록 수정

## 관련 이슈
- Closes #102 

## 테스트 방법
- [x] JWT 발급 후 payload에 `sub`(userId), `role`이 정상 포함되는지 확인
<img width="1300" height="501" alt="image" src="https://github.com/user-attachments/assets/fcd61ad3-d3ae-4525-b227-c39a41f390f2" />
- [ ] 로컬 서버 실행 후 기존 API 정상 호출 여부 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 리뷰어가 이해할 수 있도록 설명 작성
- [x] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- JWT 파싱 최적화 방식이 적절한지