### PR TITLE
feat : 대댓글 기능 추가

### DIFF
--- a/src/main/java/katecam/hyuswim/admin/service/AdminUserService.java
+++ b/src/main/java/katecam/hyuswim/admin/service/AdminUserService.java
@@ -41,7 +41,7 @@ public class AdminUserService {
                 .map(p -> new UserDetailResponse.PostSummary(p.getId(), p.getTitle(), p.getCreatedAt()))
                 .collect(Collectors.toList());
 
-        var comments = commentRepository.findAllByUser_IdAndIsDeletedFalse(userId).stream()
+        var comments = commentRepository.findAllByUserIdAndIsDeletedFalse(userId).stream()
                 .map(c -> new UserDetailResponse.CommentSummary(c.getId(), c.getContent(), c.getCreatedAt()))
                 .collect(Collectors.toList());
 

--- a/src/main/java/katecam/hyuswim/comment/controller/CommentController.java
+++ b/src/main/java/katecam/hyuswim/comment/controller/CommentController.java
@@ -1,5 +1,6 @@
 package katecam.hyuswim.comment.controller;
 
+import katecam.hyuswim.comment.dto.CommentTreeResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -26,15 +27,26 @@ public class CommentController {
   @PostMapping("/posts/{postId}/comments")
   public ResponseEntity<CommentDetailResponse> createComment(
       @PathVariable Long postId, @LoginUser User user, @RequestBody CommentRequest request) {
-    CommentDetailResponse response = commentService.createComment(request, user, postId);
+    CommentDetailResponse response = commentService.createComment(user, postId, request);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
+  @PostMapping("/comments/{parentId}/replies")
+  public ResponseEntity<CommentTreeResponse> createReplyComment(
+            @LoginUser User user,
+            @PathVariable Long parentId,
+            @RequestBody CommentRequest request
+  ) {
+      CommentTreeResponse response = commentService.createReplyComment(user, parentId, request);
+      return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
   @GetMapping("/posts/{postId}/comments")
   public ResponseEntity<PageResponse<CommentListResponse>> getComments(
+      @PathVariable Long postId,
       @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC, size = 10)
           Pageable pageable) {
-    return ResponseEntity.ok(commentService.getComments(pageable));
+    return ResponseEntity.ok(commentService.getComments(postId,pageable));
   }
 
   @GetMapping("/comments/{id}")

--- a/src/main/java/katecam/hyuswim/comment/controller/CommentController.java
+++ b/src/main/java/katecam/hyuswim/comment/controller/CommentController.java
@@ -17,6 +17,8 @@ import katecam.hyuswim.post.dto.PageResponse;
 import katecam.hyuswim.user.User;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -47,6 +49,14 @@ public class CommentController {
       @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC, size = 10)
           Pageable pageable) {
     return ResponseEntity.ok(commentService.getComments(postId,pageable));
+  }
+
+  @GetMapping("/comments/{parentId}/replies")
+  public ResponseEntity<List<CommentTreeResponse>> getReplies(
+            @PathVariable Long parentId
+  ) {
+      List<CommentTreeResponse> response = commentService.getReplies(parentId);
+      return ResponseEntity.ok(response);
   }
 
   @GetMapping("/comments/{id}")

--- a/src/main/java/katecam/hyuswim/comment/domain/Comment.java
+++ b/src/main/java/katecam/hyuswim/comment/domain/Comment.java
@@ -1,6 +1,8 @@
 package katecam.hyuswim.comment.domain;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -24,15 +26,22 @@ public class Comment {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  private String content;
-
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id")
+  @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "post_id")
+  @JoinColumn(name = "post_id", nullable = false)
   private Post post;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent_id")
+  private Comment parent;
+
+  @OneToMany(mappedBy = "parent")
+  private List<Comment> children = new ArrayList<>();
+
+  private String content;
 
   @Column(name = "is_anonymous")
   private Boolean isAnonymous = false;
@@ -54,6 +63,11 @@ public class Comment {
     this.post = post;
     this.content = content;
     this.isAnonymous = isAnonymous;
+  }
+
+  public void assignParent(Comment parent){
+      this.parent = parent;
+      parent.getChildren().add(this);
   }
 
   public void update(String content) {

--- a/src/main/java/katecam/hyuswim/comment/dto/CommentDetailResponse.java
+++ b/src/main/java/katecam/hyuswim/comment/dto/CommentDetailResponse.java
@@ -19,15 +19,15 @@ public class CommentDetailResponse {
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
-  public static CommentDetailResponse from(Comment entity) {
+  public static CommentDetailResponse from(Comment comment) {
     return CommentDetailResponse.builder()
-        .id(entity.getId())
-        .postId(entity.getPost().getId())
-        .author(entity.getUser().getNickname())
-        .content(entity.getContent())
-        .isAnonymous(entity.getIsAnonymous())
-        .createdAt(entity.getCreatedAt())
-        .updatedAt(entity.getUpdatedAt())
+        .id(comment.getId())
+        .postId(comment.getPost().getId())
+        .author(comment.getUser().getNickname())
+        .content(comment.getContent())
+        .isAnonymous(comment.getIsAnonymous())
+        .createdAt(comment.getCreatedAt())
+        .updatedAt(comment.getUpdatedAt())
         .build();
   }
 }

--- a/src/main/java/katecam/hyuswim/comment/dto/CommentListResponse.java
+++ b/src/main/java/katecam/hyuswim/comment/dto/CommentListResponse.java
@@ -18,16 +18,20 @@ public class CommentListResponse {
   private Boolean isAnonymous;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
+  private boolean hasChildren;
 
-  public static CommentListResponse from(Comment entity) {
-    return CommentListResponse.builder()
-        .id(entity.getId())
-        .postId(entity.getPost().getId())
-        .author(entity.getUser().getNickname())
-        .content(entity.getContent())
-        .isAnonymous(entity.getIsAnonymous())
-        .createdAt(entity.getCreatedAt())
-        .updatedAt(entity.getUpdatedAt())
-        .build();
-  }
+    public static CommentListResponse from(Comment comment, boolean hasChildren) {
+        return CommentListResponse.builder()
+                .id(comment.getId())
+                .postId(comment.getPost().getId())
+                .author(comment.getUser().getNickname())
+                .content(comment.getIsDeleted()
+                        ? (hasChildren ? "삭제된 댓글입니다." : null)
+                        : comment.getContent())
+                .isAnonymous(comment.getIsAnonymous())
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .hasChildren(hasChildren)
+                .build();
+    }
 }

--- a/src/main/java/katecam/hyuswim/comment/dto/CommentRequest.java
+++ b/src/main/java/katecam/hyuswim/comment/dto/CommentRequest.java
@@ -1,11 +1,11 @@
 package katecam.hyuswim.comment.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class CommentRequest {
-  private String content;
-  private Boolean isAnonymous;
+  private final String content;
+  private final Boolean isAnonymous;
 }

--- a/src/main/java/katecam/hyuswim/comment/dto/CommentTreeResponse.java
+++ b/src/main/java/katecam/hyuswim/comment/dto/CommentTreeResponse.java
@@ -4,23 +4,30 @@ import katecam.hyuswim.comment.domain.Comment;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
 @RequiredArgsConstructor
 public class CommentTreeResponse {
     private final Long id;
+    private final Long postId;
     private final String content;
     private final String author;
     private final boolean isDeleted;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
     private final List<CommentTreeResponse> children;
 
     public static CommentTreeResponse from(Comment comment){
         return new CommentTreeResponse(
                 comment.getId(),
+                comment.getPost().getId(),
                 comment.getContent(),
                 comment.getUser().getNickname(),
                 comment.getIsDeleted(),
+                comment.getCreatedAt(),
+                comment.getUpdatedAt(),
                 comment.getChildren().stream()
                         .map(katecam.hyuswim.comment.dto.CommentTreeResponse::from)
                         .toList()

--- a/src/main/java/katecam/hyuswim/comment/dto/CommentTreeResponse.java
+++ b/src/main/java/katecam/hyuswim/comment/dto/CommentTreeResponse.java
@@ -18,7 +18,7 @@ public class CommentTreeResponse {
     public static CommentTreeResponse from(Comment comment){
         return new CommentTreeResponse(
                 comment.getId(),
-                comment.getIsDeleted() ? "삭제된 댓글입니다." : comment.getContent(),
+                comment.getContent(),
                 comment.getUser().getNickname(),
                 comment.getIsDeleted(),
                 comment.getChildren().stream()

--- a/src/main/java/katecam/hyuswim/comment/dto/CommentTreeResponse.java
+++ b/src/main/java/katecam/hyuswim/comment/dto/CommentTreeResponse.java
@@ -1,0 +1,30 @@
+package katecam.hyuswim.comment.dto;
+
+import katecam.hyuswim.comment.domain.Comment;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class CommentTreeResponse {
+    private final Long id;
+    private final String content;
+    private final String author;
+    private final boolean isDeleted;
+    private final List<CommentTreeResponse> children;
+
+    public static CommentTreeResponse from(Comment comment){
+        return new CommentTreeResponse(
+                comment.getId(),
+                comment.getIsDeleted() ? "삭제된 댓글입니다." : comment.getContent(),
+                comment.getUser().getNickname(),
+                comment.getIsDeleted(),
+                comment.getChildren().stream()
+                        .map(katecam.hyuswim.comment.dto.CommentTreeResponse::from)
+                        .toList()
+
+        );
+    }
+}

--- a/src/main/java/katecam/hyuswim/comment/repository/CommentRepository.java
+++ b/src/main/java/katecam/hyuswim/comment/repository/CommentRepository.java
@@ -8,11 +8,18 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import katecam.hyuswim.comment.domain.Comment;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-  Page<Comment> findByPostIdAndParentIsNullAndIsDeletedFalse(Long postId, Pageable pageable);
+  Page<Comment> findByPostIdAndParentIsNull(Long postId, Pageable pageable);
 
   List<Comment> findByParentIdAndIsDeletedFalse(Long parentId);
+
+  @Query("select case when exists (" +
+            "select 1 from Comment c where c.parent.id = :parentId and c.isDeleted = false" +
+            ") then true else false end " +
+            "from Comment c")
+  boolean existsByParentIdAndIsDeletedFalse(Long parentId);
 
   Optional<Comment> findByIdAndIsDeletedFalse(Long id);
 

--- a/src/main/java/katecam/hyuswim/comment/repository/CommentRepository.java
+++ b/src/main/java/katecam/hyuswim/comment/repository/CommentRepository.java
@@ -10,9 +10,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import katecam.hyuswim.comment.domain.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-  Page<Comment> findAllByIsDeletedFalse(Pageable pageable);
+  Page<Comment> findByPostIdAndParentIsNullAndIsDeletedFalse(Long postId, Pageable pageable);
+
+  List<Comment> findByParentIdAndIsDeletedFalse(Long parentId);
 
   Optional<Comment> findByIdAndIsDeletedFalse(Long id);
 
-  List<Comment> findAllByUser_IdAndIsDeletedFalse(Long userId);
+  List<Comment> findAllByUserIdAndIsDeletedFalse(Long userId);
 }

--- a/src/main/java/katecam/hyuswim/comment/service/CommentService.java
+++ b/src/main/java/katecam/hyuswim/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package katecam.hyuswim.comment.service;
 
+import com.sun.source.doctree.CommentTree;
 import katecam.hyuswim.comment.dto.CommentTreeResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,8 @@ import katecam.hyuswim.post.dto.PageResponse;
 import katecam.hyuswim.post.repository.PostRepository;
 import katecam.hyuswim.user.User;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -72,6 +75,13 @@ public class CommentService {
   public PageResponse<CommentListResponse> getComments(Long postId, Pageable pageable) {
     return new PageResponse<>(
         commentRepository.findByPostIdAndParentIsNullAndIsDeletedFalse(postId,pageable).map(CommentListResponse::from));
+  }
+
+  public List<CommentTreeResponse> getReplies(Long parentId){
+      List<Comment> children = commentRepository.findByParentIdAndIsDeletedFalse(parentId);
+      return children.stream()
+              .map(CommentTreeResponse::from)
+              .toList();
   }
 
   public CommentDetailResponse getComment(Long id) {

--- a/src/main/java/katecam/hyuswim/comment/service/CommentService.java
+++ b/src/main/java/katecam/hyuswim/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package katecam.hyuswim.comment.service;
 
+import katecam.hyuswim.comment.dto.CommentTreeResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -25,7 +26,7 @@ public class CommentService {
   private final PostRepository postRepository;
 
   @Transactional
-  public CommentDetailResponse createComment(CommentRequest request, User user, Long postId) {
+  public CommentDetailResponse createComment(User user, Long postId, CommentRequest request) {
     Post post =
         postRepository
             .findById(postId)
@@ -44,9 +45,33 @@ public class CommentService {
     return CommentDetailResponse.from(saved);
   }
 
-  public PageResponse<CommentListResponse> getComments(Pageable pageable) {
+  @Transactional
+  public CommentTreeResponse createReplyComment(User user, Long parentId, CommentRequest request){
+
+      Comment parent = commentRepository.findById(parentId)
+              .orElseThrow(()-> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+      Post post = parent.getPost();
+      if (post.getIsDeleted()) {
+          throw new CustomException(ErrorCode.POST_DELETED);
+      }
+      Comment reply = Comment.builder()
+              .user(user)
+              .post(post)
+              .content(request.getContent())
+              .isAnonymous(request.getIsAnonymous())
+              .build();
+
+      reply.assignParent(parent);
+
+      commentRepository.save(reply);
+
+      return CommentTreeResponse.from(reply);
+  }
+
+  public PageResponse<CommentListResponse> getComments(Long postId, Pageable pageable) {
     return new PageResponse<>(
-        commentRepository.findAllByIsDeletedFalse(pageable).map(CommentListResponse::from));
+        commentRepository.findByPostIdAndParentIsNullAndIsDeletedFalse(postId,pageable).map(CommentListResponse::from));
   }
 
   public CommentDetailResponse getComment(Long id) {

--- a/src/main/java/katecam/hyuswim/comment/service/CommentService.java
+++ b/src/main/java/katecam/hyuswim/comment/service/CommentService.java
@@ -74,7 +74,11 @@ public class CommentService {
 
   public PageResponse<CommentListResponse> getComments(Long postId, Pageable pageable) {
     return new PageResponse<>(
-        commentRepository.findByPostIdAndParentIsNullAndIsDeletedFalse(postId,pageable).map(CommentListResponse::from));
+        commentRepository.findByPostIdAndParentIsNull(postId,pageable).map(comment -> CommentListResponse.from(
+                comment,
+                commentRepository.existsByParentIdAndIsDeletedFalse(comment.getId())
+        ))
+    );
   }
 
   public List<CommentTreeResponse> getReplies(Long parentId){

--- a/src/main/java/katecam/hyuswim/common/error/ErrorCode.java
+++ b/src/main/java/katecam/hyuswim/common/error/ErrorCode.java
@@ -1,27 +1,42 @@
 package katecam.hyuswim.common.error;
 
 import org.springframework.http.HttpStatus;
-
 import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
-  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-  LOGIN_FAILED(HttpStatus.FORBIDDEN, "아이디 또는 비밀번호가 잘못되었습니다"),
-  INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
-  POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
-  COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
-  POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "작성자만 게시글을 수정/삭제할 수 있습니다."),
-  COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "작성자만 댓글을 수정/삭제할 수 있습니다."),
-  LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요가 존재하지 않습니다."),
-  REPORT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "기타 사유 선택 시 내용은 필수입니다."),
-  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 오류가 발생했습니다.");
 
-  private final HttpStatus status;
-  private final String message;
+    //User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    LOGIN_FAILED(HttpStatus.FORBIDDEN, "아이디 또는 비밀번호가 잘못되었습니다"),
 
-  ErrorCode(HttpStatus status, String message) {
-    this.status = status;
-    this.message = message;
-  }
+    //Auth
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+
+    //Post
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
+    POST_DELETED(HttpStatus.GONE, "삭제된 게시글입니다."),
+    POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "작성자만 게시글을 수정/삭제할 수 있습니다."),
+
+    //Comment
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
+    COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "작성자만 댓글을 수정/삭제할 수 있습니다."),
+
+    //Like
+    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요가 존재하지 않습니다."),
+
+    //Report
+    REPORT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "기타 사유 선택 시 내용은 필수입니다."),
+
+    //Common
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
 }
+


### PR DESCRIPTION
## 작업 개요
- 대댓글 작성, 대댓글 조회 기능 추가

## 상세 내용
- `POST /comments/{commentId}/replies` 엔드포인트 추가 → 특정 댓글에 대댓글 작성 가능  
- `GET /comments/{commentId}/replies` 엔드포인트 추가 → 대댓글 목록 조회 가능  
- `CommentTreeResponse` DTO 추가
- `CommentListResponse`에 `hasChildren` 필드 추가 → 루트 댓글에서 대댓글 존재 여부 확인 가능  

## 관련 이슈
- Closes #107 

## 테스트 방법
- [x] 로컬 서버 실행 후 대댓글 작성 API 호출 → 201 Created, 저장된 데이터 DB 확인  
- [x] 대댓글 조회 API 호출 → children 구조 확인 및 삭제 처리 검증  
- [x] 대댓글이 달린 루트 댓글 삭제 시 `"삭제된 댓글입니다."` 표시 확인  
- [x] 대댓글 삭제 시 응답에서 제외되는지 확인  

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 리뷰어가 이해할 수 있도록 설명 작성
- [x] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 대댓글 작성과 댓글 작성을 분리한게 적절한지
- 삭제된 댓글입니다 처리를 DTO에서 처리한 부분이 적절할지
(도메인에 넣던 엔티티에 넣던 애매...한데 별도의 Formatter/헬퍼 클래스를 적용하기에도 지금은 과하다는 생각에 일단 간단한 방향을 구현)

대댓글 조회를 어떻게 할지부터해서 많이 고민하게 됐던 기능이었네요.
루트 댓글 조회시에 같이하게 하냐, 나눠서 하냐도 고민 됐는데 분리하는 구조가 응답 데이터 최적화도 되고 나중에 프론트 측에서 답글 더보기로 할지 같이 보여줄지 등을 마음대로 선택할 수 있을 것 같아 현재와 같이 구현했습니다. 

루트 댓글 삭제 시에 밑에 달린 대댓글까지 안 보이는 상태가 되면 안되니까 이 부분도 많이 고민을 했는데, 대댓글이 달린 루트 댓글이 삭제되면 "삭제된 댓글입니다"를, 달리지 않은 루트 댓글이 삭제되면 null 처리해서 프론트 측에서 null 일 경우 보여주지 않도록 처리하게끔 했습니다. 기존에는 삭제된 댓긓은 조회가 안되는 쿼리를 쓰고 있었어서 일단 부모가 null인 것만 조회하게끔 하고 이후 대댓글 존재 여부 쿼리를 추가해서 해결했습니다.

대댓글을 한 개만 달게하냐 무한하게 달게하냐도 고민이었는데 대댓글 기능 자체가 유저들간의 자유로운 소통을 위한 것이니 무한으로 대댓글을 계속 이어가는게 커뮤니티 목적과도 맞아 현재와 같은 트리 구조로 구현하게 됐습니다.