### PR TITLE
refactor : ReportService 및 PostCategory 개선

### DIFF
--- a/src/main/java/katecam/hyuswim/common/error/ErrorCode.java
+++ b/src/main/java/katecam/hyuswim/common/error/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요가 존재하지 않습니다."),
 
     //Report
+    INVALID_REPORT_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않은 신고 타입입니다."),
     REPORT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "기타 사유 선택 시 내용은 필수입니다."),
 
     //Common

--- a/src/main/java/katecam/hyuswim/post/domain/PostCategory.java
+++ b/src/main/java/katecam/hyuswim/post/domain/PostCategory.java
@@ -1,15 +1,15 @@
 package katecam.hyuswim.post.domain;
 
 public enum PostCategory {
-  FREE("자유"),
-  CAREER("진로취업"),
-  STUDY("학업"),
-  RELATIONSHIP("대인관계"),
-  SOCIAL("사회생활"),
-  MENTAL("정신건강"),
-  HOBBY("취미/자기계발"),
-  FAMILY("가족"),
-  TROUBLE("고민상담");
+    FREE("자유"),
+    STUDY("학업"),
+    CAREER("진로취업"),
+    RELATIONSHIP("대인관계"),
+    SOCIAL("사회생활"),
+    FAMILY("가족"),
+    HOBBY("취미"),
+    MENTAL("정신건강"),
+    TROUBLE("고민상담");
 
   private final String displayName;
 

--- a/src/main/java/katecam/hyuswim/report/service/ReportService.java
+++ b/src/main/java/katecam/hyuswim/report/service/ReportService.java
@@ -39,19 +39,22 @@ public class ReportService {
   public void report(User reporter, ReportRequest request) {
     User reportedUser;
 
-    if (request.getReportType() == ReportType.POST) {
-      Post post =
-          postRepository
-              .findById(request.getTargetId())
-              .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-      reportedUser = post.getUser();
-    } else {
-      Comment comment =
-          commentRespository
-              .findById(request.getTargetId())
-              .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
-      reportedUser = comment.getUser();
+    switch(request.getReportType()){
+        case POST -> {
+            Post post = postRepository
+                    .findById(request.getTargetId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+            reportedUser = post.getUser();
+        }
+        case COMMENT -> {
+            Comment comment = commentRespository
+                    .findById(request.getTargetId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+            reportedUser = comment.getUser();
+        }
+        default -> throw new CustomException(ErrorCode.INVALID_REPORT_TYPE);
     }
+
 
     Report report =
         Report.create(


### PR DESCRIPTION
## 작업 개요
- Report 처리 로직 switch 구문으로 변경
- PostCategory enum 노출 순서 개선 
- displayname 취미/자기계발에서 자기계발 제거

## 상세 내용
- ReportService 내 if-else 분기 로직을 switch 구문으로 리팩토링
 - default 구문 추가하여 INVALID_REPORT_TYPE 예외 처리
- PostCategory enum 노출 순서 변경
  - 기존 무작위 나열 → 사용자 친화적 순서 (가벼운 → 무거운 카테고리 흐름)
  - FREE, STUDY, CAREER, RELATIONSHIP, SOCIAL, FAMILY, HOBBY, MENTAL, TROUBLE

## 관련 이슈
- Closes #113 

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 리뷰어가 이해할 수 있도록 설명 작성
- [x] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- ReportType switch 구문 구조가 적절하게 적용되었는지
- PostCategory 노출 순서가 사용자 경험 측면에서 적절한지