### PR TITLE
feat: 닉네임,자기소개 변경 api 구현

### DIFF
--- a/src/main/java/katecam/hyuswim/common/error/ErrorCode.java
+++ b/src/main/java/katecam/hyuswim/common/error/ErrorCode.java
@@ -8,7 +8,7 @@ public enum ErrorCode {
 
     //User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    LOGIN_FAILED(HttpStatus.FORBIDDEN, "아이디 또는 비밀번호가 잘못되었습니다"),
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 잘못되었습니다"),
 
     //Auth
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),

--- a/src/main/java/katecam/hyuswim/user/User.java
+++ b/src/main/java/katecam/hyuswim/user/User.java
@@ -66,10 +66,9 @@ public class User {
   @Column(name = "updated_at")
   private LocalDateTime updatedAt;
 
-  public User(String email, String password, String nickname) {
+  public User(String email, String password) {
     this.email = email;
     this.password = password;
-    this.nickname = nickname;
     this.role = UserRole.USER;
   }
 

--- a/src/main/java/katecam/hyuswim/user/User.java
+++ b/src/main/java/katecam/hyuswim/user/User.java
@@ -31,7 +31,7 @@ public class User {
 
   private String password;
 
-  private String nickname;
+  private String nickname = "새싹이";
 
   private String introduction;
 

--- a/src/main/java/katecam/hyuswim/user/User.java
+++ b/src/main/java/katecam/hyuswim/user/User.java
@@ -3,6 +3,7 @@ package katecam.hyuswim.user;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -19,6 +20,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor
+@Setter
 public class User {
 
   @Id
@@ -30,6 +32,8 @@ public class User {
   private String password;
 
   private String nickname;
+
+  private String introduction;
 
   @OneToMany(mappedBy = "user")
   private List<Badge> badges;
@@ -100,4 +104,9 @@ public class User {
     this.blockedUntil = null;
     this.blockReason = reason;
   }
+
+    public void updateProfile(String nickname, String introduction) {
+        this.nickname = nickname;
+        this.introduction = introduction;
+    }
 }

--- a/src/main/java/katecam/hyuswim/user/User.java
+++ b/src/main/java/katecam/hyuswim/user/User.java
@@ -20,7 +20,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor
-@Setter
 public class User {
 
   @Id

--- a/src/main/java/katecam/hyuswim/user/User.java
+++ b/src/main/java/katecam/hyuswim/user/User.java
@@ -30,7 +30,7 @@ public class User {
 
   private String password;
 
-  private String nickname = "새싹이";
+  private String nickname;
 
   private String introduction;
 
@@ -68,6 +68,7 @@ public class User {
   public User(String email, String password) {
     this.email = email;
     this.password = password;
+    this.nickname = "새싹이";
     this.role = UserRole.USER;
   }
 

--- a/src/main/java/katecam/hyuswim/user/controller/MyPageController.java
+++ b/src/main/java/katecam/hyuswim/user/controller/MyPageController.java
@@ -2,17 +2,12 @@ package katecam.hyuswim.user.controller;
 
 import java.util.List;
 
+import katecam.hyuswim.user.dto.mypage.*;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import katecam.hyuswim.auth.login.LoginUser;
 import katecam.hyuswim.user.User;
-import katecam.hyuswim.user.dto.mypage.MyCommentResponse;
-import katecam.hyuswim.user.dto.mypage.MyLikedPostResponse;
-import katecam.hyuswim.user.dto.mypage.MyOverviewResponse;
-import katecam.hyuswim.user.dto.mypage.MyPostListReponse;
 import katecam.hyuswim.user.service.MyPageService;
 import lombok.RequiredArgsConstructor;
 
@@ -41,5 +36,10 @@ public class MyPageController {
   @GetMapping("/me/liked-posts")
   public ResponseEntity<List<MyLikedPostResponse>> myLikedPostList(@LoginUser User loginUser) {
     return ResponseEntity.ok(myPageService.selectMyLikedPostList(loginUser));
+  }
+
+  @PatchMapping("/me/profile/edit/info")
+  public ResponseEntity<ProfileUpdate> updateMyProfile(@LoginUser User loginUser, @RequestBody ProfileUpdate profileUpdate) {
+    return ResponseEntity.ok(myPageService.updateUserProfile(loginUser, profileUpdate));
   }
 }

--- a/src/main/java/katecam/hyuswim/user/controller/MyPageController.java
+++ b/src/main/java/katecam/hyuswim/user/controller/MyPageController.java
@@ -39,7 +39,8 @@ public class MyPageController {
   }
 
   @PatchMapping("/me/profile/edit/info")
-  public ResponseEntity<ProfileUpdate> updateMyProfile(@LoginUser User loginUser, @RequestBody ProfileUpdate profileUpdate) {
-    return ResponseEntity.ok(myPageService.updateUserProfile(loginUser, profileUpdate));
+  public ResponseEntity<Void> updateMyProfile(@LoginUser User loginUser, @RequestBody ProfileUpdate profileUpdate) {
+    myPageService.updateUserProfile(loginUser, profileUpdate);
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/katecam/hyuswim/user/controller/UserController.java
+++ b/src/main/java/katecam/hyuswim/user/controller/UserController.java
@@ -21,9 +21,9 @@ public class UserController {
   private final JwtUtil jwtUtil;
 
   @PostMapping("/api/user/signup")
-  public ResponseEntity<String> postSignup(@RequestBody SignupRequest signupRequest) {
+  public ResponseEntity<Void> postSignup(@RequestBody SignupRequest signupRequest) {
     userService.saveUser(signupRequest);
-    return ResponseEntity.status(HttpStatus.CREATED).body("회원가입 완료");
+    return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
   @PostMapping("/api/auth/login")

--- a/src/main/java/katecam/hyuswim/user/dto/SignupRequest.java
+++ b/src/main/java/katecam/hyuswim/user/dto/SignupRequest.java
@@ -8,5 +8,4 @@ public class SignupRequest {
 
   private String email;
   private String password;
-  private String nickname;
 }

--- a/src/main/java/katecam/hyuswim/user/dto/mypage/ProfileUpdate.java
+++ b/src/main/java/katecam/hyuswim/user/dto/mypage/ProfileUpdate.java
@@ -1,0 +1,13 @@
+package katecam.hyuswim.user.dto.mypage;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProfileUpdate {
+
+    private String nickname;
+
+    private String introduction;
+}

--- a/src/main/java/katecam/hyuswim/user/service/MyPageService.java
+++ b/src/main/java/katecam/hyuswim/user/service/MyPageService.java
@@ -2,7 +2,13 @@ package katecam.hyuswim.user.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import katecam.hyuswim.common.error.CustomException;
+import katecam.hyuswim.common.error.ErrorCode;
+import katecam.hyuswim.user.dto.mypage.*;
+import katecam.hyuswim.user.exception.UserNotFoundException;
+import katecam.hyuswim.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,10 +17,6 @@ import katecam.hyuswim.like.domain.PostLike;
 import katecam.hyuswim.like.repository.PostLikeRepository;
 import katecam.hyuswim.post.domain.Post;
 import katecam.hyuswim.user.User;
-import katecam.hyuswim.user.dto.mypage.MyCommentResponse;
-import katecam.hyuswim.user.dto.mypage.MyLikedPostResponse;
-import katecam.hyuswim.user.dto.mypage.MyOverviewResponse;
-import katecam.hyuswim.user.dto.mypage.MyPostListReponse;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -22,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class MyPageService {
 
   private final PostLikeRepository postLikeRepository;
+  private final UserRepository userRepository;
 
   @Transactional
   public MyOverviewResponse selectMyOverview(User loginUser) {
@@ -77,4 +80,11 @@ public class MyPageService {
   public int selectMyLikesCount(Long userId) {
     return postLikeRepository.countByUserId(userId);
   }
+
+  @Transactional
+  public ProfileUpdate updateUserProfile(User loginUser, ProfileUpdate profileUpdate) {
+    loginUser.updateProfile(profileUpdate.getNickname(), profileUpdate.getIntroduction());
+    return new ProfileUpdate(loginUser.getNickname(), loginUser.getIntroduction());
+  }
+
 }

--- a/src/main/java/katecam/hyuswim/user/service/MyPageService.java
+++ b/src/main/java/katecam/hyuswim/user/service/MyPageService.java
@@ -82,9 +82,8 @@ public class MyPageService {
   }
 
   @Transactional
-  public ProfileUpdate updateUserProfile(User loginUser, ProfileUpdate profileUpdate) {
+  public void updateUserProfile(User loginUser, ProfileUpdate profileUpdate) {
     loginUser.updateProfile(profileUpdate.getNickname(), profileUpdate.getIntroduction());
-    return new ProfileUpdate(loginUser.getNickname(), loginUser.getIntroduction());
   }
 
 }

--- a/src/main/java/katecam/hyuswim/user/service/UserService.java
+++ b/src/main/java/katecam/hyuswim/user/service/UserService.java
@@ -29,7 +29,7 @@ public class UserService {
     String encPassword = bCryptPasswordEncoder.encode(signupRequest.getPassword());
 
     userRepository.save(
-        new User(signupRequest.getEmail(), encPassword, signupRequest.getNickname()));
+        new User(signupRequest.getEmail(), encPassword));
   }
 
   @Transactional


### PR DESCRIPTION
## 작업 개요
- 회원가입 시 닉네임 입력 제거
- 닉네임 자기소개 변경 API구현
- 응답코드 변경
- 닉네임유효성검사 같은경우 추후 해도 될것같아서 안햇씁니다

## 상세 내용
- 닉네임,자기소개 변경기능구현
```
{
  "nickname": "새벽이",
  "introduction": "함께 성장하는 것을 좋아해요! 🌱"
}
```
- 기본닉네임 새싹이로 설정
- 회원가입시 닉네임제거

리팩토링
- 회원가입시 201코드만 주게변경
- 로그인 실패시 403코드에서 401로 뜨게 변경
- 로그인 실패시 401코드
```
{
    "status": 401,
    "code": "LOGIN_FAILED",
    "message": "아이디 또는 비밀번호가 잘못되었습니다"
}
```

## 관련 이슈
- Closes #76 
- Related to #이슈번호

## 테스트 방법
- [X] 로컬 서버 실행 후 API 호출 결과 확인
- [X] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [X] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [X] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 