### PR TITLE
[Chore] 로컬 개발 환경 DB H2 -> MySQL(Docker)로 교체

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### env ###
 .env
+
+# MySQL local volume
+mysql-data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: local-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "${DB_PORT}:3306"
+    volumes:
+      - ./mysql-data:/var/lib/mysql
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,26 +1,16 @@
 spring:
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH
-    username: sa
-    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: update   # dev 환경용, 운영은 validate 권장
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.MySQL8Dialect
         globally_quoted_identifiers: true
-
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-      settings:
-        web-allow-others: false
-
-
-
-
+    show-sql: true


### PR DESCRIPTION
## 작업 개요
- 로컬 개발 환경 DB를 H2에서 MySQL(Docker) 기반으로 교체

## 상세 내용
- docker-compose.yml 추가하여 MySQL 컨테이너 실행 환경 구성
- .env 기반으로 DB 접속 정보 관리
- .gitignore에 mysql-data/ 추가 (로컬 데이터 파일 제외)

## 관련 이슈
- Closes #60 

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수


## 리뷰 중점 사항
- 