### PR TITLE
[Feat] 관리자 페이지 신고 조회

### DIFF
--- a/src/main/java/katecam/hyuswim/admin/controller/AdminReportController.java
+++ b/src/main/java/katecam/hyuswim/admin/controller/AdminReportController.java
@@ -1,0 +1,40 @@
+package katecam.hyuswim.admin.controller;
+
+import katecam.hyuswim.admin.service.AdminReportService;
+import katecam.hyuswim.report.domain.ReportStatus;
+import katecam.hyuswim.report.dto.ReportDetailResponse;
+import katecam.hyuswim.report.dto.ReportListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/reports")
+public class AdminReportController {
+
+    private final AdminReportService adminReportService;
+
+
+    @GetMapping
+    public ResponseEntity<List<ReportListResponse>> getReports() {
+        return ResponseEntity.ok(adminReportService.getReports());
+    }
+
+
+    @GetMapping("/{reportId}")
+    public ResponseEntity<ReportDetailResponse> getReport(@PathVariable Long reportId) {
+        return ResponseEntity.ok(adminReportService.getReport(reportId));
+    }
+
+
+    @PatchMapping("/{reportId}/status")
+    public ResponseEntity<ReportDetailResponse> updateStatus(
+            @PathVariable Long reportId,
+            @RequestParam ReportStatus status
+    ) {
+        return ResponseEntity.ok(adminReportService.updateStatus(reportId, status));
+    }
+}

--- a/src/main/java/katecam/hyuswim/admin/service/AdminReportService.java
+++ b/src/main/java/katecam/hyuswim/admin/service/AdminReportService.java
@@ -1,0 +1,44 @@
+package katecam.hyuswim.admin.service;
+
+import katecam.hyuswim.common.error.CustomException;
+import katecam.hyuswim.report.domain.Report;
+import katecam.hyuswim.report.domain.ReportStatus;
+import katecam.hyuswim.report.dto.ReportDetailResponse;
+import katecam.hyuswim.report.dto.ReportListResponse;
+import katecam.hyuswim.report.repository.ReportRepository;
+import katecam.hyuswim.common.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminReportService {
+
+    private final ReportRepository reportRepository;
+
+    // 신고 목록 조회 (간략 정보)
+    public List<ReportListResponse> getReports() {
+        return reportRepository.findAll().stream()
+                .map(ReportListResponse::from)
+                .toList();
+    }
+
+    // 신고 상세 조회 (전체 정보)
+    public ReportDetailResponse getReport(Long reportId) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.REPORT_NOT_FOUND));
+        return ReportDetailResponse.from(report);
+    }
+
+
+    // 신고 상태 업데이트
+    public ReportDetailResponse updateStatus(Long reportId, ReportStatus status) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.REPORT_NOT_FOUND));
+        report.updateStatus(status);
+        return ReportDetailResponse.from(reportRepository.save(report));
+    }
+}

--- a/src/main/java/katecam/hyuswim/common/error/ErrorCode.java
+++ b/src/main/java/katecam/hyuswim/common/error/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     //Report
     INVALID_REPORT_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않은 신고 타입입니다."),
     REPORT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "기타 사유 선택 시 내용은 필수입니다."),
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 신고 내역입니다."),
 
     //Common
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 오류가 발생했습니다.");

--- a/src/main/java/katecam/hyuswim/report/domain/Report.java
+++ b/src/main/java/katecam/hyuswim/report/domain/Report.java
@@ -79,4 +79,7 @@ public class Report {
 
     return new Report(reporter, reportedUser, reportType, targetId, reportReasonType, content);
   }
+  public void updateStatus(ReportStatus status) {
+      this.status = status;
+  }
 }


### PR DESCRIPTION
## 작업 개요
- 관리자 페이지 신고 조회

## 상세 내용

1. **신고 목록 조회 API**
    - `GET /admin/reports`
    - 설명: 전체 신고 내역을 조회한다.
2. **신고 상세 조회 API**
    - `GET /admin/reports/{reportId}`
    - 설명: 특정 신고 내역을 조회한다.

## 관련 이슈
- Closes #142 

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수


## 리뷰 중점 사항
- 