### PR TITLE
feat : 게시글 상세조회 시 조회수 1 증가 구현

### DIFF
--- a/src/main/java/katecam/hyuswim/post/domain/Post.java
+++ b/src/main/java/katecam/hyuswim/post/domain/Post.java
@@ -78,6 +78,10 @@ public class Post {
         .build();
   }
 
+  public void increaseViewCount(){
+      this.viewCount++;
+  }
+
   public void update(String title, String content, PostCategory postCategory) {
     if (title != null) this.title = title;
     if (content != null) this.content = content;

--- a/src/main/java/katecam/hyuswim/post/service/PostService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostService.java
@@ -53,6 +53,10 @@ public class PostService {
         postRepository
             .findByIdAndIsDeletedFalse(id)
             .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+    post.increaseViewCount();
+    postRepository.save(post);
+
     return PostDetailResponse.from(post);
   }
 


### PR DESCRIPTION
## 작업 개요
- 게시글 상세조회 시 조회수 1 증가 구현

## 상세 내용
- post에 increaseViewCount 추가 및 상세 조회 api 호출 시 마다 조회수가 1 증가하도록 추가

## 관련 이슈
- Closes #157 

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 리뷰어가 이해할 수 있도록 설명 작성
- [x] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 