### PR TITLE
refactor: PostCategory 응답에서 UI 전용 ALL 제거

### DIFF
--- a/src/main/java/katecam/hyuswim/mission/MissionCategory.java
+++ b/src/main/java/katecam/hyuswim/mission/MissionCategory.java
@@ -1,7 +1,6 @@
 package katecam.hyuswim.mission;
 
 public enum MissionCategory {
-    ALL("전체"),
     ROUTINE("루틴"),
     ACTIVITY("활동"),
     COMMUNICATION("소통"),

--- a/src/main/java/katecam/hyuswim/post/domain/PostCategory.java
+++ b/src/main/java/katecam/hyuswim/post/domain/PostCategory.java
@@ -1,7 +1,6 @@
 package katecam.hyuswim.post.domain;
 
 public enum PostCategory {
-    ALL("전체"),
     FREE("자유"),
     STUDY("학업"),
     CAREER("진로취업"),


### PR DESCRIPTION
## 작업 개요
- 카테고리 응답에서 `ALL` 옵션 제거

## 상세 내용
- PostCategory, MissionCategory Enum과 응답 로직을 실제 DB 카테고리 값만 포함하도록 수정
- 기존에 응답 JSON에 포함되던 `ALL` 제거

## 관련 이슈
- Closes #135 

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인 
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 리뷰어가 이해할 수 있도록 설명 작성
- [x] 관련 문서/주석 업데이트

## 리뷰 중점 사항
-