### PR TITLE
fix : AI 계정 provider local로 설정

### DIFF
--- a/src/main/java/katecam/hyuswim/user/domain/User.java
+++ b/src/main/java/katecam/hyuswim/user/domain/User.java
@@ -108,6 +108,7 @@ public class User {
       this.status = UserStatus.ACTIVE;
       this.commentNotificationEnabled = true;
       this.likeNotificationEnabled = true;
+      this.provider =AuthProvider.LOCAL;
     }
 
     public boolean isBlocked() {


### PR DESCRIPTION
## 작업 개요
- AI 계정 provider local로 설정

## 상세 내용
- provider이 nullable인데 AI 계정에 provider가 없어서 임의로 local로 설정

## 관련 이슈
- Closes #163 

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 리뷰어가 이해할 수 있도록 설명 작성
- [x] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 