### PR TITLE
[Feat] 관리자 페이지 게시글 숨김 / 삭제 

### DIFF
--- a/src/main/java/katecam/hyuswim/admin/controller/AdminPostController.java
+++ b/src/main/java/katecam/hyuswim/admin/controller/AdminPostController.java
@@ -30,4 +30,22 @@ public class AdminPostController {
         model.addAttribute("post", post);
         return "admin/posts/detail";
     }
+
+    @PostMapping("/{postId}/hide")
+    public String hidePost(@PathVariable Long postId) {
+        adminPostService.hidePost(postId);
+        return "redirect:/admin/posts";
+    }
+
+    @PostMapping("/{postId}/unhide")
+    public String unhidePost(@PathVariable Long postId) {
+        adminPostService.unhidePost(postId);
+        return "redirect:/admin/posts";
+    }
+
+    @DeleteMapping("/{postId}")
+    public String deletePost(@PathVariable Long postId) {
+        adminPostService.deletePost(postId);
+        return "redirect:/admin/posts";
+    }
 }

--- a/src/main/java/katecam/hyuswim/admin/service/AdminPostService.java
+++ b/src/main/java/katecam/hyuswim/admin/service/AdminPostService.java
@@ -32,4 +32,27 @@ public class AdminPostService {
 
         return AdminPostDetailResponse.from(post);
     }
+
+    // 숨김 처리
+    public void hidePost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        post.delete();
+        postRepository.save(post);
+    }
+
+    // 숨김 해제
+    public void unhidePost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        post.unhide();
+        postRepository.save(post);
+    }
+
+    // 영구 삭제 (DB 삭제)
+    public void deletePost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        postRepository.delete(post);
+    }
 }

--- a/src/main/java/katecam/hyuswim/post/domain/Post.java
+++ b/src/main/java/katecam/hyuswim/post/domain/Post.java
@@ -48,7 +48,7 @@ public class Post {
   @Column(name = "is_deleted")
   private Boolean isDeleted = false;
 
-  @Builder.Default private Long viewCount = 0L;
+    @Builder.Default private Long viewCount = 0L;
 
   @Builder.Default
   @OneToMany(mappedBy = "post")
@@ -90,5 +90,9 @@ public class Post {
 
   public void delete() {
     this.isDeleted = true;
+  }
+
+  public void unhide() {
+      this.isDeleted = false;
   }
 }

--- a/src/main/resources/templates/admin/posts/detail.html
+++ b/src/main/resources/templates/admin/posts/detail.html
@@ -23,6 +23,23 @@
     </dl>
 
     <a href="/admin/posts" class="btn btn-secondary mt-3">목록으로</a>
+
+    <!-- 숨김 -->
+    <form th:action="@{|/admin/posts/${post.id}/hide|}" method="post" style="display:inline;">
+        <button type="submit" class="btn btn-warning mt-3">숨김</button>
+    </form>
+
+    <!-- 숨김 해제 -->
+    <form th:action="@{|/admin/posts/${post.id}/unhide|}" method="post" style="display:inline;">
+        <button type="submit" class="btn btn-success mt-3">숨김 해제</button>
+    </form>
+
+    <!-- 삭제 -->
+    <form th:action="@{|/admin/posts/${post.id}|}" method="post" style="display:inline;"
+          onsubmit="return confirm('정말 삭제하시겠습니까?');">
+        <input type="hidden" name="_method" value="delete"/>
+        <button type="submit" class="btn btn-danger mt-3">삭제</button>
+    </form>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/admin/posts/list.html
+++ b/src/main/resources/templates/admin/posts/list.html
@@ -12,7 +12,7 @@
             <th>제목</th>
             <th>작성자</th>
             <th>작성일</th>
-            <th>상세</th>
+            <th>관리</th>
         </tr>
         </thead>
         <tbody>
@@ -23,6 +23,23 @@
             <td th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd HH:mm')}"></td>
             <td>
                 <a th:href="@{|/admin/posts/${post.id}|}" class="btn btn-sm btn-primary">보기</a>
+
+                <!-- 숨김 -->
+                <form th:action="@{|/admin/posts/${post.id}/hide|}" method="post" style="display:inline;">
+                    <button type="submit" class="btn btn-sm btn-warning">숨김</button>
+                </form>
+
+                <!-- 숨김 해제 -->
+                <form th:action="@{|/admin/posts/${post.id}/unhide|}" method="post" style="display:inline;">
+                    <button type="submit" class="btn btn-sm btn-success">숨김 해제</button>
+                </form>
+
+                <!-- 삭제 -->
+                <form th:action="@{|/admin/posts/${post.id}|}" method="post" style="display:inline;"
+                      onsubmit="return confirm('정말 삭제하시겠습니까?');">
+                    <input type="hidden" name="_method" value="delete"/>
+                    <button type="submit" class="btn btn-sm btn-danger">삭제</button>
+                </form>
             </td>
         </tr>
         </tbody>


### PR DESCRIPTION
## 작업 개요
- 관리자 페이지 게시글 숨김 / 삭제 구현

## 상세 내용
- Post 엔티티에 숨김/숨김 해제 메서드(hide(), unhide()) 추가
- AdminPostService에 게시글 숨김, 숨김 해제, 영구 삭제(hidePost, unhidePost, deletePost) 기능 추가
- AdminPostController에 숨김(POST /admin/posts/{postId}/hide), 숨김 해제(POST /admin/posts/{postId}/unhide), 삭제(DELETE /admin/posts/{postId}) API 추가
- 타임리프 뷰(admin-post-list.html, admin-post-detail.html)에 숨김/해제/삭제 버튼 추가

## 관련 이슈
- Closes #144 

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수


## 리뷰 중점 사항
- 