### PR TITLE
fix(auth): 회원가입 및 로그인 엔드포인트 매핑 및 보안 설정 수정

### DIFF
--- a/src/main/java/katecam/hyuswim/auth/config/DevSecurityConfig.java
+++ b/src/main/java/katecam/hyuswim/auth/config/DevSecurityConfig.java
@@ -43,7 +43,7 @@ public class DevSecurityConfig {
                     return config;
                 }))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/user/signup", "/api/auth/login").permitAll()
+                        .requestMatchers("/api/users/signup", "/api/auth/login").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/katecam/hyuswim/auth/config/LocalSecurityConfig.java
+++ b/src/main/java/katecam/hyuswim/auth/config/LocalSecurityConfig.java
@@ -42,7 +42,7 @@ public class LocalSecurityConfig {
   public SecurityFilterChain apiChain(HttpSecurity http, JwtFilter jwtFilter) throws Exception {
       http.securityMatcher("/api/**")
               .authorizeHttpRequests(auth -> auth
-                      .requestMatchers("/api/user/signup", "/api/auth/login").permitAll()
+                      .requestMatchers("/api/users/signup", "/api/auth/login").permitAll()
                       .requestMatchers("/api/admin/**").hasRole("ADMIN")
                       .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
                       .anyRequest().authenticated()

--- a/src/main/java/katecam/hyuswim/user/controller/UserController.java
+++ b/src/main/java/katecam/hyuswim/user/controller/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
-  @PostMapping("/api/auth/login")
+  @PostMapping("/auth/login")
   public ResponseEntity<?> postLogin(@RequestBody LoginRequest loginRequest) {
     String jwtToken = userService.login(loginRequest);
     return ResponseEntity.ok(new JwtTokenResponse(jwtToken));


### PR DESCRIPTION
## 작업 개요
- 회원가입 및 로그인 엔드포인트 매핑 및 보안 설정 수정

## 상세 내용
- 회원가입 앤드포인트 변경 후 세큐리티 설정에 반영하지 않았던 문제 해결
- api 리퀘스트로 묶으면서 로그인 앞에 api가 두번 들어갔던 문제 해결

## 관련 이슈
- Closes #이슈번호

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 리뷰어가 이해할 수 있도록 설명 작성
- [x] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 