### PR TITLE
[Feat] 관리자 페이지 댓글 기능

### DIFF
--- a/src/main/java/katecam/hyuswim/admin/controller/AdminCommentController.java
+++ b/src/main/java/katecam/hyuswim/admin/controller/AdminCommentController.java
@@ -1,0 +1,37 @@
+package katecam.hyuswim.admin.controller;
+
+import katecam.hyuswim.admin.dto.AdminCommentResponse;
+import katecam.hyuswim.admin.service.AdminCommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admin/comments")
+public class AdminCommentController {
+
+    private final AdminCommentService adminCommentService;
+
+    @GetMapping
+    public String comments(Model model) {
+        List<AdminCommentResponse> comments = adminCommentService.getComments();
+        model.addAttribute("comments", comments);
+        return "admin/comment-list";
+    }
+
+    @PostMapping("/{id}/hide")
+    public String hideComment(@PathVariable Long id) {
+        adminCommentService.hideComment(id);
+        return "redirect:/admin/comments";
+    }
+
+    @PostMapping("/{id}/delete")
+    public String deleteComment(@PathVariable Long id) {
+        adminCommentService.deleteComment(id);
+        return "redirect:/admin/comments";
+    }
+}

--- a/src/main/java/katecam/hyuswim/admin/dto/AdminCommentResponse.java
+++ b/src/main/java/katecam/hyuswim/admin/dto/AdminCommentResponse.java
@@ -1,0 +1,22 @@
+package katecam.hyuswim.admin.dto;
+
+import katecam.hyuswim.comment.domain.Comment;
+import java.time.LocalDateTime;
+
+public record AdminCommentResponse(
+        Long id,
+        String content,
+        String writerEmail,
+        boolean deleted,
+        LocalDateTime createdAt
+) {
+    public static AdminCommentResponse from(Comment comment) {
+        return new AdminCommentResponse(
+                comment.getId(),
+                comment.getContent(),
+                comment.getUser().getEmail(),
+                comment.getIsDeleted(),
+                comment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/katecam/hyuswim/admin/service/AdminCommentService.java
+++ b/src/main/java/katecam/hyuswim/admin/service/AdminCommentService.java
@@ -1,0 +1,33 @@
+package katecam.hyuswim.admin.service;
+
+import katecam.hyuswim.admin.dto.AdminCommentResponse;
+import katecam.hyuswim.comment.domain.Comment;
+import katecam.hyuswim.comment.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminCommentService {
+
+    private final CommentRepository commentRepository;
+
+    public List<AdminCommentResponse> getComments() {
+        return commentRepository.findAll().stream()
+                .map(AdminCommentResponse::from)
+                .toList();
+    }
+
+    public void hideComment(Long id) {
+        Comment comment = commentRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 댓글이 존재하지 않습니다."));
+        comment.delete();
+        commentRepository.save(comment);
+    }
+
+    public void deleteComment(Long id) {
+        commentRepository.deleteById(id);
+    }
+}

--- a/src/main/resources/templates/admin/Comment/list.html
+++ b/src/main/resources/templates/admin/Comment/list.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>댓글 관리</title>
+    <style>
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 20px;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 8px;
+            text-align: center;
+        }
+        th {
+            background-color: #f2f2f2;
+        }
+        form {
+            display: inline;
+        }
+        button {
+            padding: 4px 10px;
+            margin: 2px;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>댓글 관리</h1>
+
+    <table>
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>내용</th>
+            <th>작성자</th>
+            <th>작성일</th>
+            <th>상태</th>
+            <th>액션</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="comment : ${comments}">
+            <td th:text="${comment.id}"></td>
+            <td th:text="${comment.content}"></td>
+            <td th:text="${comment.writerEmail}"></td>
+            <td th:text="${#temporals.format(comment.createdAt, 'yyyy-MM-dd HH:mm')}"></td>
+            <td th:text="${comment.deleted} ? '삭제됨' : '노출중'"></td>
+            <td>
+                <form th:action="@{/admin/comments/{id}/hide(id=${comment.id})}" method="post">
+                    <button type="submit">숨김</button>
+                </form>
+                <form th:action="@{/admin/comments/{id}/delete(id=${comment.id})}" method="post">
+                    <button type="submit">삭제</button>
+                </form>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 작업 개요
- 관리자 페이지 댓글 관리 기능 구현

## 상세 내용
- 댓글 목록 조회 기능 추가 (/admin/comments)
- 댓글 삭제 기능 추가 (/admin/comments/{id}/delete)
- AdminCommentController, AdminCommentService, AdminCommentResponse 작성
- comment-list.html 템플릿 추가

## 관련 이슈
- Closes #174 

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수


## 리뷰 중점 사항
- 