### PR TITLE
[Refactor] User 엔티티 책임 분리 및 관리자 페이지 email 삭제

### DIFF
--- a/src/main/java/katecam/hyuswim/admin/dto/AdminCommentResponse.java
+++ b/src/main/java/katecam/hyuswim/admin/dto/AdminCommentResponse.java
@@ -6,7 +6,6 @@ import java.time.LocalDateTime;
 public record AdminCommentResponse(
         Long id,
         String content,
-        String writerEmail,
         boolean deleted,
         LocalDateTime createdAt
 ) {
@@ -14,7 +13,6 @@ public record AdminCommentResponse(
         return new AdminCommentResponse(
                 comment.getId(),
                 comment.getContent(),
-                comment.getUser().getEmail(),
                 comment.getIsDeleted(),
                 comment.getCreatedAt()
         );

--- a/src/main/java/katecam/hyuswim/user/domain/User.java
+++ b/src/main/java/katecam/hyuswim/user/domain/User.java
@@ -1,6 +1,7 @@
 package katecam.hyuswim.user.domain;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.data.annotation.CreatedDate;
@@ -43,10 +44,6 @@ public class User {
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = false;
 
-    private LocalDateTime blockedUntil;
-
-    private String blockReason;
-
     @Column(name = "comment_notification_enabled", nullable = false)
     private Boolean commentNotificationEnabled = true;
 
@@ -71,6 +68,9 @@ public class User {
     @OneToMany(mappedBy = "user")
     private List<MissionProgress> missionProgresses;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserBlockHistory> blockHistories = new ArrayList<>();
+
     @Column(name = "last_active_date")
     @CreatedDate
     private LocalDateTime lastActiveDate;
@@ -92,24 +92,6 @@ public class User {
         this.introduction = introduction;
         this.role = role;
         this.handle = "@" + generateHandle();
-    }
-
-    public void blockUntil(LocalDateTime until, String reason) {
-        this.status = UserStatus.BLOCKED;
-        this.blockedUntil = until;
-        this.blockReason = reason;
-    }
-
-    public void unblock() {
-        this.status = UserStatus.ACTIVE;
-        this.blockedUntil = null;
-        this.blockReason = null;
-    }
-
-    public void ban(String reason) {
-        this.status = UserStatus.BANNED;
-        this.blockedUntil = null;
-        this.blockReason = reason;
     }
 
     public void delete() {
@@ -144,7 +126,7 @@ public class User {
         }
         return sb.toString();
     }
-  
+
     public void addPoints(long points) {
         if (points > 0) {
             this.points += points;
@@ -154,4 +136,9 @@ public class User {
     public void updateLastActiveDate() {
         this.lastActiveDate = LocalDateTime.now();
     }
+
+    public void setStatus(UserStatus status) {
+        this.status = status;
+    }
+
 }

--- a/src/main/java/katecam/hyuswim/user/domain/UserBlockHistory.java
+++ b/src/main/java/katecam/hyuswim/user/domain/UserBlockHistory.java
@@ -19,6 +19,10 @@ public class UserBlockHistory {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserStatus status;
+
     private LocalDateTime blockedUntil;
 
     private String reason;
@@ -26,8 +30,9 @@ public class UserBlockHistory {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
 
-    public UserBlockHistory(User user, LocalDateTime blockedUntil, String reason) {
+    public UserBlockHistory(User user, UserStatus status, LocalDateTime blockedUntil, String reason) {
         this.user = user;
+        this.status = status;
         this.blockedUntil = blockedUntil;
         this.reason = reason;
     }

--- a/src/main/java/katecam/hyuswim/user/domain/UserBlockHistory.java
+++ b/src/main/java/katecam/hyuswim/user/domain/UserBlockHistory.java
@@ -1,0 +1,34 @@
+package katecam.hyuswim.user.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class UserBlockHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private LocalDateTime blockedUntil;
+
+    private String reason;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public UserBlockHistory(User user, LocalDateTime blockedUntil, String reason) {
+        this.user = user;
+        this.blockedUntil = blockedUntil;
+        this.reason = reason;
+    }
+}


### PR DESCRIPTION
## 작업 개요
- User 엔티티 책임 분리
- 관리자 페이지 email 부분 삭제

## 상세 내용
- User 엔티티 -> User, UserBlockHistory 분리
- 관리자 페이지 AdminUserService 수정

## 관련 이슈
- Closes #188 
- Related to #이슈번호

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수


## 리뷰 중점 사항
- 