### PR TITLE
feat: 게시글 전체 개수 반환 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-env.example
+.env.example
 JWT_SECRET=
 EC2_HOST=
 DB_USER=

--- a/src/main/java/katecam/hyuswim/post/controller/PostStatController.java
+++ b/src/main/java/katecam/hyuswim/post/controller/PostStatController.java
@@ -1,5 +1,6 @@
 package katecam.hyuswim.post.controller;
 
+import katecam.hyuswim.post.dto.PostCountResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +16,11 @@ import lombok.RequiredArgsConstructor;
 public class PostStatController {
 
   private final PostStatService postStatService;
+
+  @GetMapping("/count")
+  public ResponseEntity<PostCountResponse> getPostcount(){
+      return ResponseEntity.ok(postStatService.getPostCount());
+  }
 
   @GetMapping("/stats")
   public ResponseEntity<PostStatsResponse> getPostStats() {

--- a/src/main/java/katecam/hyuswim/post/dto/PostCountResponse.java
+++ b/src/main/java/katecam/hyuswim/post/dto/PostCountResponse.java
@@ -1,0 +1,12 @@
+package katecam.hyuswim.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostCountResponse {
+    private long totalCount;
+}

--- a/src/main/java/katecam/hyuswim/post/service/PostStatService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostStatService.java
@@ -4,6 +4,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import katecam.hyuswim.post.dto.PostCountResponse;
 import org.springframework.stereotype.Service;
 
 import katecam.hyuswim.post.dto.PostStatsResponse;
@@ -31,4 +32,11 @@ public class PostStatService {
 
     return new PostStatsResponse(totalCount, weekCount, todayCount);
   }
+
+  public PostCountResponse getPostCount(){
+      long totalCount = postRepository.countByIsDeletedFalse();
+
+      return new PostCountResponse(totalCount);
+  }
+
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,6 +15,11 @@ spring:
         globally_quoted_identifiers: true
     show-sql: true
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
 jwt:
   secret: ${JWT_SECRET}
 


### PR DESCRIPTION
## 작업 개요
- 게시글 전체 개수 반환 api 추가

## 상세 내용
**- application-local.yml에 redis 설정 추가**
- 게시글 전체 개수 반환 api (Get /api/posts/count) 추가

## 관련 이슈
- Closes #194 

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 리뷰어가 이해할 수 있도록 설명 작성
- [x] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 