### PR TITLE
[Feat] 지원 사업 관리 기능 구현

### DIFF
--- a/src/main/java/katecam/hyuswim/admin/controller/AdminSupportController.java
+++ b/src/main/java/katecam/hyuswim/admin/controller/AdminSupportController.java
@@ -1,0 +1,37 @@
+package katecam.hyuswim.admin.controller;
+
+import katecam.hyuswim.support.domain.Support;
+import katecam.hyuswim.support.dto.SupportDetailResponse;
+import katecam.hyuswim.admin.service.AdminSupportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/support-links")
+public class AdminSupportController {
+
+    private final AdminSupportService adminSupportService;
+
+    // 신규 지원 사업 등록
+    @PostMapping
+    public ResponseEntity<SupportDetailResponse> createSupport(@RequestBody Support support) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(adminSupportService.createSupport(support));
+    }
+
+    // 지원 사업 정보 수정
+    @PatchMapping("/{id}")
+    public ResponseEntity<SupportDetailResponse> updateSupport(@PathVariable Long id,
+                                                               @RequestBody Support updateRequest) {
+        return ResponseEntity.ok(adminSupportService.updateSupport(id, updateRequest));
+    }
+
+    // 지원 사업 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteSupport(@PathVariable Long id) {
+        adminSupportService.deleteSupport(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/katecam/hyuswim/admin/service/AdminSupportService.java
+++ b/src/main/java/katecam/hyuswim/admin/service/AdminSupportService.java
@@ -30,7 +30,7 @@ public class AdminSupportService {
                 updateRequest.getCompany(),
                 updateRequest.getContent(),
                 updateRequest.getPlace(),
-                updateRequest.getEndPoint(),
+                updateRequest.getEndDate(),
                 updateRequest.getSupportType()
         );
 

--- a/src/main/java/katecam/hyuswim/admin/service/AdminSupportService.java
+++ b/src/main/java/katecam/hyuswim/admin/service/AdminSupportService.java
@@ -1,0 +1,47 @@
+package katecam.hyuswim.admin.service;
+
+import katecam.hyuswim.common.error.CustomException;
+import katecam.hyuswim.common.error.ErrorCode;
+import katecam.hyuswim.support.domain.Support;
+import katecam.hyuswim.support.dto.SupportDetailResponse;
+import katecam.hyuswim.support.repository.SupportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminSupportService {
+
+    private final SupportRepository supportRepository;
+
+    // 신규 등록
+    public SupportDetailResponse createSupport(Support support) {
+        Support saved = supportRepository.save(support);
+        return SupportDetailResponse.from(saved);
+    }
+
+    // 수정
+    public SupportDetailResponse updateSupport(Long id, Support updateRequest) {
+        Support support = supportRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUPPORT_NOT_FOUND));
+
+        support.update(
+                updateRequest.getName(),
+                updateRequest.getCompany(),
+                updateRequest.getContent(),
+                updateRequest.getPlace(),
+                updateRequest.getEndPoint(),
+                updateRequest.getSupportType()
+        );
+
+        Support updated = supportRepository.save(support);
+        return SupportDetailResponse.from(updated);
+    }
+
+    // 삭제
+    public void deleteSupport(Long id) {
+        Support support = supportRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUPPORT_NOT_FOUND));
+        supportRepository.delete(support);
+    }
+}

--- a/src/main/java/katecam/hyuswim/support/controller/SupportController.java
+++ b/src/main/java/katecam/hyuswim/support/controller/SupportController.java
@@ -1,15 +1,15 @@
 package katecam.hyuswim.support.controller;
 
-import katecam.hyuswim.common.error.CustomException;
-import katecam.hyuswim.common.error.ErrorCode;
 import katecam.hyuswim.support.domain.SupportType;
 import katecam.hyuswim.support.dto.SupportResponse;
 import katecam.hyuswim.support.dto.SupportDetailResponse;
 import katecam.hyuswim.support.service.SupportService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,26 +18,24 @@ public class SupportController {
 
     private final SupportService supportService;
 
-    // 지원 사업 목록 조회
     @GetMapping
-    public List<SupportResponse> getAllSupports() {
-        return supportService.getAllSupports();
+    public ResponseEntity<List<SupportResponse>> getAllSupports() {
+        return ResponseEntity.ok(supportService.getAllSupports());
     }
 
-    // 지원 사업 카테고리 조회
     @GetMapping("/type/{type}")
-    public List<SupportResponse> getSupportsByType(@PathVariable String type) {
-        try {
-            SupportType supportType = SupportType.valueOf(type.toUpperCase());
-            return supportService.getSupportsByType(supportType);
-        } catch (IllegalArgumentException e) {
-            throw new CustomException(ErrorCode.INVALID_SUPPORT_TYPE);
-        }
+    public ResponseEntity<List<SupportResponse>> getSupportsByType(@PathVariable SupportType type) {
+        return ResponseEntity.ok(supportService.getSupportsByType(type));
     }
 
-    // 지원 사업 상세 조회
-    @GetMapping("/{programId}")
-    public SupportDetailResponse getSupportDetail(@PathVariable Long programId) {
-        return supportService.getSupportDetail(programId);
+    @GetMapping("/{id}")
+    public ResponseEntity<SupportDetailResponse> getSupportDetail(@PathVariable Long id) {
+        return ResponseEntity.ok(supportService.getSupportDetail(id));
+    }
+
+    @GetMapping("/count")
+    public ResponseEntity<Map<String, Long>> getActiveSupportCount() {
+        return ResponseEntity.ok(Map.of("count", supportService.getActiveSupportCount()));
     }
 }
+

--- a/src/main/java/katecam/hyuswim/support/domain/Support.java
+++ b/src/main/java/katecam/hyuswim/support/domain/Support.java
@@ -41,4 +41,14 @@ public class Support {
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    public void update(String name, String company, String content, String place, LocalDate endPoint, SupportType type) {
+        if (name != null) this.name = name;
+        if (company != null) this.company = company;
+        if (content != null) this.content = content;
+        if (place != null) this.place = place;
+        if (endPoint != null) this.endPoint = endPoint;
+        if (type != null) this.supportType = type;
+    }
+
 }

--- a/src/main/java/katecam/hyuswim/support/domain/Support.java
+++ b/src/main/java/katecam/hyuswim/support/domain/Support.java
@@ -34,6 +34,8 @@ public class Support {
 
     private LocalDate endDate;
 
+    private String url;
+
     @CreatedDate
     @Column(name = "created_at", updatable = false, nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/katecam/hyuswim/support/domain/Support.java
+++ b/src/main/java/katecam/hyuswim/support/domain/Support.java
@@ -32,7 +32,7 @@ public class Support {
 
     private String place;
 
-    private LocalDate endPoint;
+    private LocalDate endDate;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false, nullable = false)
@@ -42,12 +42,12 @@ public class Support {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    public void update(String name, String company, String content, String place, LocalDate endPoint, SupportType type) {
+    public void update(String name, String company, String content, String place, LocalDate endDate, SupportType type) {
         if (name != null) this.name = name;
         if (company != null) this.company = company;
         if (content != null) this.content = content;
         if (place != null) this.place = place;
-        if (endPoint != null) this.endPoint = endPoint;
+        if (endDate != null) this.endDate = endDate;
         if (type != null) this.supportType = type;
     }
 

--- a/src/main/java/katecam/hyuswim/support/domain/SupportType.java
+++ b/src/main/java/katecam/hyuswim/support/domain/SupportType.java
@@ -1,5 +1,16 @@
 package katecam.hyuswim.support.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum SupportType {
-  TEMP
+    EDUCATION("교육"),
+    STARTUP("창업"),
+    EMPLOYMENT("취업"),
+    WELFARE("복지"),
+    CULTURE("문화");
+
+    private final String displayName;
 }

--- a/src/main/java/katecam/hyuswim/support/dto/SupportDetailResponse.java
+++ b/src/main/java/katecam/hyuswim/support/dto/SupportDetailResponse.java
@@ -21,6 +21,7 @@ public class SupportDetailResponse {
     private String content;
     private String place;
     private LocalDate endDate;
+    private String url;
 
     public static SupportDetailResponse from(Support support) {
         return SupportDetailResponse.builder()
@@ -32,6 +33,7 @@ public class SupportDetailResponse {
                 .content(support.getContent())
                 .place(support.getPlace())
                 .endDate(support.getEndDate())
+                .url(support.getUrl())
                 .build();
     }
 }

--- a/src/main/java/katecam/hyuswim/support/dto/SupportDetailResponse.java
+++ b/src/main/java/katecam/hyuswim/support/dto/SupportDetailResponse.java
@@ -16,7 +16,8 @@ public class SupportDetailResponse {
     private Long id;
     private String name;
     private String company;
-    private SupportType supportType;
+    private SupportType supportType;    
+    private String supportTypeName;
     private String content;
     private String place;
     private LocalDate endPoint;
@@ -27,6 +28,7 @@ public class SupportDetailResponse {
                 .name(support.getName())
                 .company(support.getCompany())
                 .supportType(support.getSupportType())
+                .supportTypeName(support.getSupportType().getDisplayName())
                 .content(support.getContent())
                 .place(support.getPlace())
                 .endPoint(support.getEndPoint())

--- a/src/main/java/katecam/hyuswim/support/dto/SupportDetailResponse.java
+++ b/src/main/java/katecam/hyuswim/support/dto/SupportDetailResponse.java
@@ -16,11 +16,11 @@ public class SupportDetailResponse {
     private Long id;
     private String name;
     private String company;
-    private SupportType supportType;    
+    private SupportType supportType;
     private String supportTypeName;
     private String content;
     private String place;
-    private LocalDate endPoint;
+    private LocalDate endDate;
 
     public static SupportDetailResponse from(Support support) {
         return SupportDetailResponse.builder()
@@ -31,7 +31,7 @@ public class SupportDetailResponse {
                 .supportTypeName(support.getSupportType().getDisplayName())
                 .content(support.getContent())
                 .place(support.getPlace())
-                .endPoint(support.getEndPoint())
+                .endDate(support.getEndDate())
                 .build();
     }
 }

--- a/src/main/java/katecam/hyuswim/support/dto/SupportResponse.java
+++ b/src/main/java/katecam/hyuswim/support/dto/SupportResponse.java
@@ -19,6 +19,7 @@ public class SupportResponse {
     private SupportType supportType;
     private String supportTypeName;
     private LocalDate endDate;
+    private String url;
 
     public static SupportResponse from(Support support) {
         return SupportResponse.builder()
@@ -28,6 +29,7 @@ public class SupportResponse {
                 .supportType(support.getSupportType())
                 .supportTypeName(support.getSupportType().getDisplayName())
                 .endDate(support.getEndDate())
+                .url(support.getUrl())
                 .build();
     }
 }

--- a/src/main/java/katecam/hyuswim/support/dto/SupportResponse.java
+++ b/src/main/java/katecam/hyuswim/support/dto/SupportResponse.java
@@ -18,7 +18,7 @@ public class SupportResponse {
     private String company;
     private SupportType supportType;
     private String supportTypeName;
-    private LocalDate endPoint;
+    private LocalDate endDate;
 
     public static SupportResponse from(Support support) {
         return SupportResponse.builder()
@@ -27,7 +27,7 @@ public class SupportResponse {
                 .company(support.getCompany())
                 .supportType(support.getSupportType())
                 .supportTypeName(support.getSupportType().getDisplayName())
-                .endPoint(support.getEndPoint())
+                .endDate(support.getEndDate())
                 .build();
     }
 }

--- a/src/main/java/katecam/hyuswim/support/dto/SupportResponse.java
+++ b/src/main/java/katecam/hyuswim/support/dto/SupportResponse.java
@@ -17,6 +17,7 @@ public class SupportResponse {
     private String name;
     private String company;
     private SupportType supportType;
+    private String supportTypeName;
     private LocalDate endPoint;
 
     public static SupportResponse from(Support support) {
@@ -25,6 +26,7 @@ public class SupportResponse {
                 .name(support.getName())
                 .company(support.getCompany())
                 .supportType(support.getSupportType())
+                .supportTypeName(support.getSupportType().getDisplayName())
                 .endPoint(support.getEndPoint())
                 .build();
     }

--- a/src/main/java/katecam/hyuswim/support/repository/SupportRepository.java
+++ b/src/main/java/katecam/hyuswim/support/repository/SupportRepository.java
@@ -5,11 +5,14 @@ import katecam.hyuswim.support.domain.SupportType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface SupportRepository extends JpaRepository<Support, Long> {
 
     List<Support> findBySupportType(SupportType supportType);
-    @Query("SELECT COUNT(s) FROM Support s WHERE s.endPoint >= CURRENT_DATE")
+    @Query("SELECT COUNT(s) FROM Support s WHERE s.endDate >= CURRENT_DATE")
     long countActiveSupports();
+
+    long countByEndDateAfter(LocalDate date);
 }

--- a/src/main/java/katecam/hyuswim/support/repository/SupportRepository.java
+++ b/src/main/java/katecam/hyuswim/support/repository/SupportRepository.java
@@ -3,10 +3,13 @@ package katecam.hyuswim.support.repository;
 import katecam.hyuswim.support.domain.Support;
 import katecam.hyuswim.support.domain.SupportType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface SupportRepository extends JpaRepository<Support, Long> {
 
     List<Support> findBySupportType(SupportType supportType);
+    @Query("SELECT COUNT(s) FROM Support s WHERE s.endPoint >= CURRENT_DATE")
+    long countActiveSupports();
 }

--- a/src/main/java/katecam/hyuswim/support/service/SupportService.java
+++ b/src/main/java/katecam/hyuswim/support/service/SupportService.java
@@ -51,12 +51,15 @@ public class SupportService {
         Support support = supportRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.SUPPORT_NOT_FOUND));
 
-        if (updateRequest.getName() != null) support.setName(updateRequest.getName());
-        if (updateRequest.getCompany() != null) support.setCompany(updateRequest.getCompany());
-        if (updateRequest.getContent() != null) support.setContent(updateRequest.getContent());
-        if (updateRequest.getPlace() != null) support.setPlace(updateRequest.getPlace());
-        if (updateRequest.getEndPoint() != null) support.setEndPoint(updateRequest.getEndPoint());
-        if (updateRequest.getSupportType() != null) support.setSupportType(updateRequest.getSupportType());
+        support.update(
+                updateRequest.getName(),
+                updateRequest.getCompany(),
+                updateRequest.getContent(),
+                updateRequest.getPlace(),
+                updateRequest.getEndPoint(),
+                updateRequest.getSupportType()
+        );
+
 
         Support updated = supportRepository.save(support);
         return SupportDetailResponse.from(updated);

--- a/src/main/java/katecam/hyuswim/support/service/SupportService.java
+++ b/src/main/java/katecam/hyuswim/support/service/SupportService.java
@@ -46,7 +46,7 @@ public class SupportService {
         Support saved = supportRepository.save(support);
         return SupportDetailResponse.from(saved);
     }
-    
+
     public SupportDetailResponse updateSupport(Long id, Support updateRequest) {
         Support support = supportRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.SUPPORT_NOT_FOUND));
@@ -61,5 +61,12 @@ public class SupportService {
         Support updated = supportRepository.save(support);
         return SupportDetailResponse.from(updated);
     }
+
+    public void deleteSupport(Long id) {
+        Support support = supportRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUPPORT_NOT_FOUND));
+        supportRepository.delete(support);
+    }
+
 
 }

--- a/src/main/java/katecam/hyuswim/support/service/SupportService.java
+++ b/src/main/java/katecam/hyuswim/support/service/SupportService.java
@@ -37,4 +37,10 @@ public class SupportService {
                 .orElseThrow(() -> new CustomException(ErrorCode.SUPPORT_NOT_FOUND));
         return SupportDetailResponse.from(support);
     }
+
+    public long getActiveSupportCount() {
+        return supportRepository.countActiveSupports();
+    }
+
+    
 }

--- a/src/main/java/katecam/hyuswim/support/service/SupportService.java
+++ b/src/main/java/katecam/hyuswim/support/service/SupportService.java
@@ -18,6 +18,7 @@ public class SupportService {
 
     private final SupportRepository supportRepository;
 
+    // 전체 조회
     public List<SupportResponse> getAllSupports() {
         return supportRepository.findAll()
                 .stream()
@@ -25,6 +26,7 @@ public class SupportService {
                 .toList();
     }
 
+    // 카테고리별 조회
     public List<SupportResponse> getSupportsByType(SupportType type) {
         return supportRepository.findBySupportType(type)
                 .stream()
@@ -32,44 +34,16 @@ public class SupportService {
                 .toList();
     }
 
+    // 상세 조회
     public SupportDetailResponse getSupportDetail(Long id) {
         Support support = supportRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.SUPPORT_NOT_FOUND));
         return SupportDetailResponse.from(support);
     }
 
+    // 진행 중인 개수 조회
     public long getActiveSupportCount() {
         return supportRepository.countActiveSupports();
     }
-
-    public SupportDetailResponse createSupport(Support support) {
-        Support saved = supportRepository.save(support);
-        return SupportDetailResponse.from(saved);
-    }
-
-    public SupportDetailResponse updateSupport(Long id, Support updateRequest) {
-        Support support = supportRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.SUPPORT_NOT_FOUND));
-
-        support.update(
-                updateRequest.getName(),
-                updateRequest.getCompany(),
-                updateRequest.getContent(),
-                updateRequest.getPlace(),
-                updateRequest.getEndPoint(),
-                updateRequest.getSupportType()
-        );
-
-
-        Support updated = supportRepository.save(support);
-        return SupportDetailResponse.from(updated);
-    }
-
-    public void deleteSupport(Long id) {
-        Support support = supportRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.SUPPORT_NOT_FOUND));
-        supportRepository.delete(support);
-    }
-
-
 }
+

--- a/src/main/java/katecam/hyuswim/support/service/SupportService.java
+++ b/src/main/java/katecam/hyuswim/support/service/SupportService.java
@@ -42,5 +42,24 @@ public class SupportService {
         return supportRepository.countActiveSupports();
     }
 
+    public SupportDetailResponse createSupport(Support support) {
+        Support saved = supportRepository.save(support);
+        return SupportDetailResponse.from(saved);
+    }
     
+    public SupportDetailResponse updateSupport(Long id, Support updateRequest) {
+        Support support = supportRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUPPORT_NOT_FOUND));
+
+        if (updateRequest.getName() != null) support.setName(updateRequest.getName());
+        if (updateRequest.getCompany() != null) support.setCompany(updateRequest.getCompany());
+        if (updateRequest.getContent() != null) support.setContent(updateRequest.getContent());
+        if (updateRequest.getPlace() != null) support.setPlace(updateRequest.getPlace());
+        if (updateRequest.getEndPoint() != null) support.setEndPoint(updateRequest.getEndPoint());
+        if (updateRequest.getSupportType() != null) support.setSupportType(updateRequest.getSupportType());
+
+        Support updated = supportRepository.save(support);
+        return SupportDetailResponse.from(updated);
+    }
+
 }

--- a/src/main/java/katecam/hyuswim/support/service/SupportService.java
+++ b/src/main/java/katecam/hyuswim/support/service/SupportService.java
@@ -10,6 +10,7 @@ import katecam.hyuswim.support.repository.SupportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -43,7 +44,9 @@ public class SupportService {
 
     // 진행 중인 개수 조회
     public long getActiveSupportCount() {
-        return supportRepository.countActiveSupports();
+        return supportRepository.countByEndDateAfter(LocalDate.now());
     }
+
+
 }
 


### PR DESCRIPTION
## 작업 개요
- 지원 사업 관리 기능 구현 (등록, 수정, 삭제, 개수 조회)

## 상세 내용
- 신규 지원 사업 등록 API (POST /api/admin/support-links) 구현
- 지원 사업 정보 수정 API (PATCH /api/admin/support-links/{programId}) 구현
- 지원 사업 삭제 API (DELETE /api/admin/support-links/{programId}) 구현
- 진행 중인 지원 사업 개수 조회 API (GET /api/support-programs/count) 구현
- ErrorCode에 SUPPORT_NOT_FOUND 추가하여 예외 처리 일원화
- 지원 사업 카테고리 추가 및 display 구현
- EndPoint -> EndDate로 수정
- URL 필드 추가

## 관련 이슈
- Closes #147 
- Closes #148 

## 테스트 방법
- [x] 로컬 서버 실행 후 API 호출 결과 확인
- [x] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 리뷰어가 이해할 수 있도록 설명 작성
- [x] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 