### PR TITLE
feat : 구글/카카오 로그인 콜백 시 프론트 리다이렉트 및 토큰 전달 방식으로 변경

### DIFF
--- a/src/main/java/katecam/hyuswim/auth/controller/GoogleAuthController.java
+++ b/src/main/java/katecam/hyuswim/auth/controller/GoogleAuthController.java
@@ -1,13 +1,11 @@
 package katecam.hyuswim.auth.controller;
 
 import jakarta.servlet.http.HttpServletResponse;
-import katecam.hyuswim.auth.dto.AccessTokenResponse;
 import katecam.hyuswim.auth.dto.LoginTokens;
 import katecam.hyuswim.auth.service.GoogleAuthService;
 import katecam.hyuswim.auth.util.CookieUtil;
 import katecam.hyuswim.auth.util.RedirectUrlBuilder;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpHeaders;

--- a/src/main/java/katecam/hyuswim/auth/controller/GoogleAuthController.java
+++ b/src/main/java/katecam/hyuswim/auth/controller/GoogleAuthController.java
@@ -1,10 +1,13 @@
 package katecam.hyuswim.auth.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import katecam.hyuswim.auth.dto.AccessTokenResponse;
 import katecam.hyuswim.auth.dto.LoginTokens;
 import katecam.hyuswim.auth.service.GoogleAuthService;
 import katecam.hyuswim.auth.util.CookieUtil;
+import katecam.hyuswim.auth.util.RedirectUrlBuilder;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpHeaders;
@@ -13,12 +16,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth/google")
 public class GoogleAuthController {
 
     private final CookieUtil cookieUtil;
+    private final RedirectUrlBuilder redirectUrlBuilder;
     private final GoogleAuthService googleAuthService;
 
     @GetMapping("/url")
@@ -26,15 +32,16 @@ public class GoogleAuthController {
         return ResponseEntity.ok(googleAuthService.generateLoginUrl());
     }
 
+
     @GetMapping("/callback")
-    public ResponseEntity<AccessTokenResponse> googleCallback(@RequestParam("code") String code) {
+    public void googleCallback(@RequestParam("code") String code, HttpServletResponse response) throws IOException {
         LoginTokens tokens = googleAuthService.loginWithGoogle(code);
 
         ResponseCookie refreshTokenCookie = cookieUtil.createRefreshTokenCookie(tokens.refreshToken());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
-        return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-                .body(new AccessTokenResponse(tokens.accessToken()));
+        String redirectUrl = redirectUrlBuilder.buildGoogleRedirectUrl(tokens.accessToken());
+        response.sendRedirect(redirectUrl);
     }
 }
 

--- a/src/main/java/katecam/hyuswim/auth/controller/KakaoAuthController.java
+++ b/src/main/java/katecam/hyuswim/auth/controller/KakaoAuthController.java
@@ -1,9 +1,10 @@
 package katecam.hyuswim.auth.controller;
 
-import katecam.hyuswim.auth.dto.AccessTokenResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import katecam.hyuswim.auth.dto.LoginTokens;
 import katecam.hyuswim.auth.service.KakaoAuthService;
 import katecam.hyuswim.auth.util.CookieUtil;
+import katecam.hyuswim.auth.util.RedirectUrlBuilder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -13,12 +14,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth/kakao")
 public class KakaoAuthController {
 
     private final CookieUtil cookieUtil;
+    private final RedirectUrlBuilder redirectUrlBuilder;
     private final KakaoAuthService kakaoAuthService;
 
     @GetMapping("/url")
@@ -27,13 +31,13 @@ public class KakaoAuthController {
     }
 
     @GetMapping("/callback")
-    public ResponseEntity<AccessTokenResponse> kakaoCallback(@RequestParam("code") String code) {
+    public void kakaoCallback(@RequestParam("code") String code, HttpServletResponse response) throws IOException {
         LoginTokens tokens = kakaoAuthService.loginWithKakao(code);
 
         ResponseCookie refreshTokenCookie = cookieUtil.createRefreshTokenCookie(tokens.refreshToken());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
-        return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-                .body(new AccessTokenResponse(tokens.accessToken()));
+        String redirectUrl = redirectUrlBuilder.buildKakaoRedirectUrl(tokens.accessToken());
+        response.sendRedirect(redirectUrl);
     }
 }

--- a/src/main/java/katecam/hyuswim/auth/service/GoogleAuthService.java
+++ b/src/main/java/katecam/hyuswim/auth/service/GoogleAuthService.java
@@ -52,8 +52,8 @@ public class GoogleAuthService {
 
     @Transactional
     public LoginTokens loginWithGoogle(String code) {
-        GoogleTokenResponse tokenResponse = requestToken(code);
-        GoogleIdTokenPayload payload = extractPayload(tokenResponse.idToken());
+        GoogleTokenResponse tokenResponse = requestGoogleToken(code);
+        GoogleIdTokenPayload payload = parseIdTokenPayload(tokenResponse.idToken());
         String sub = payload.sub();
 
         UserAuth userAuth = userAuthRepository.findByProviderAndProviderIdAndUser_IsDeletedFalse(AuthProvider.GOOGLE, sub)
@@ -69,7 +69,7 @@ public class GoogleAuthService {
         return new LoginTokens(accessToken, refreshToken);
     }
 
-    private GoogleTokenResponse requestToken(String code) {
+    private GoogleTokenResponse requestGoogleToken(String code) {
         URI uri = URI.create(googleProperties.tokenUri());
 
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
@@ -92,7 +92,7 @@ public class GoogleAuthService {
     }
 
 
-    private GoogleIdTokenPayload extractPayload(String idToken) {
+    private GoogleIdTokenPayload parseIdTokenPayload(String idToken) {
         try {
             String[] parts = idToken.split("\\.");
             if (parts.length < 2) {

--- a/src/main/java/katecam/hyuswim/auth/util/RedirectUrlBuilder.java
+++ b/src/main/java/katecam/hyuswim/auth/util/RedirectUrlBuilder.java
@@ -1,0 +1,17 @@
+package katecam.hyuswim.auth.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedirectUrlBuilder {
+
+    @Value("${frontend.urls}")
+    private String[] frontendUrls;
+
+    public String buildGoogleRedirectUrl(String accessToken) {
+        return frontendUrls[1] + "/oauth/callback/google#accessToken=" + accessToken;
+    }
+}

--- a/src/main/java/katecam/hyuswim/auth/util/RedirectUrlBuilder.java
+++ b/src/main/java/katecam/hyuswim/auth/util/RedirectUrlBuilder.java
@@ -14,4 +14,8 @@ public class RedirectUrlBuilder {
     public String buildGoogleRedirectUrl(String accessToken) {
         return frontendUrls[1] + "/oauth/callback/google#accessToken=" + accessToken;
     }
+
+    public String buildKakaoRedirectUrl(String accessToken) {
+        return frontendUrls[1] + "/oauth/callback/kakao#accessToken=" + accessToken;
+    }
 }


### PR DESCRIPTION
## 작업 개요
- 구글/카카오 로그인 콜백 시 프론트 리다이렉트 및 토큰 전달 방식으로 변경

## 상세 내용
- 구글 OAuth 콜백 처리 방식을 JSON 응답에서 프론트 리다이렉트 방식으로 변경
기존
- /api/auth/google/callback 호출 시 accessToken JSON 응답 + refreshToken 쿠키 반환
변경
accessToken → URL 해시(#) 파라미터로 전달
예: /oauth/callback/google#accessToken=...
refreshToken → HttpOnly 쿠키로 전달
프론트는 해시 파라미터에서 accessToken 꺼내 localStorage/sessionStorage 저장 후 사용
- RedirectUrlBuilder 추가
## 관련 이슈
- Closes #207 

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 