### PR TITLE
fix(cicd): MySQL 8.0 접속 오류 해결을 위한 allowPublicKeyRetrieval 옵션 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -159,7 +159,7 @@ jobs:
 
             # 기동
             echo "Starting new application (${APP_JAR})... Logging to ${LOG_FILE_PATH}"
-            JAVA_OPTS="--spring.datasource.url=jdbc:mysql://${{ secrets.EC2_HOST }}:3306/${{ secrets.DB_NAME }}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8 \
+            JAVA_OPTS="--spring.datasource.url=jdbc:mysql://${{ secrets.EC2_HOST }}:3306/${{ secrets.DB_NAME }}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8 \
             --spring.datasource.username=${{ secrets.DB_USER }} \
             --spring.datasource.password=${{ secrets.DB_PASSWORD }} \
             --jwt.secret=${{ secrets.JWT_SECRET }} \


### PR DESCRIPTION
## 작업 개요
-  MySQL 8.0 접속 오류 해결을 위한 allowPublicKeyRetrieval 옵션 추가

## 상세 내용
- 배포 스크립트(deploy.yml)에서 spring.datasource.url에 allowPublicKeyRetrieval=true 옵션을 추가
-MySQL 8.0 이상에서 기본 인증 방식(caching_sha2_password)을 사용할 때, JDBC 드라이버가 서버 공개키를 가져오지 못해 Public Key Retrieval is not allowed 오류가 발생했음

1.DB 계정 인증 방식을 mysql_native_password로 변경
2.JDBC URL에 allowPublicKeyRetrieval=true 옵션 추가

두가지 해결 방법 중 운영 보안 요구가 낮은 환경(내부 개발용)에서는 2번 옵션 추가가 가장 간단하고 즉시 적용 가능해서  allowPublicKeyRetrieval=true 옵션을 URL에 추가하는 방식으로 해결

## 관련 이슈
- Closes #이슈번호

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 