### PR TITLE
fix: AppProperties가 빈으로 등록되지 않던 문제 해결

### DIFF
--- a/src/main/java/katecam/hyuswim/common/config/AppProperties.java
+++ b/src/main/java/katecam/hyuswim/common/config/AppProperties.java
@@ -1,9 +1,11 @@
 package katecam.hyuswim.common.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
 
+@Configuration
 @ConfigurationProperties(prefix = "app")
 public record AppProperties(List<String> frontendUrls) {}
 


### PR DESCRIPTION
## 작업 개요
- AppProperties가 빈으로 등록되지 않던 문제 해결

## 상세 내용
-

## 관련 이슈
- Closes #이슈번호
- Related to #이슈번호

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 