### PR TITLE
fix: 배포 파이프라인에서 최신 JAR 파일만 업로드하도록 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,20 +45,19 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build -x test
 
-      # 6) 빌드 산출물(SNAPSHOT) 파일명 추출
-      - name: Find and export JAR file name
+      # 6) 빌드 산출물(JAR) 파일명 추출 (최신 파일만)
+      - name: Find and export latest JAR file name
         id: find_jar
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t FILES < <(find build/libs -maxdepth 1 -type f -name "*-SNAPSHOT.jar" | sort)
-          if [ ${#FILES[@]} -eq 0 ]; then
-            echo "::error::No SNAPSHOT JAR file found in build/libs/"
+          FILE=$(ls -t build/libs/*.jar | head -n1)
+          if [ -z "$FILE" ]; then
+            echo "::error::No JAR file found in build/libs/"
             exit 1
           fi
-          JAR_FILE_PATH="${FILES[0]}"
-          JAR_FILE_NAME="$(basename "$JAR_FILE_PATH")"
-          echo "Found JAR file: $JAR_FILE_NAME"
+          JAR_FILE_NAME="$(basename "$FILE")"
+          echo "Found latest JAR file: $JAR_FILE_NAME"
           echo "JAR_NAME=$JAR_FILE_NAME" >> "$GITHUB_OUTPUT"
 
       # (디버그) 빌드 산출물 확인


### PR DESCRIPTION
## 작업 개요
- 배포 파이프라인에서 최신 JAR 파일만 업로드하도록 수정

## 상세 내용
- 

## 관련 이슈
- Closes #이슈번호
- Related to #이슈번호

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 