### PR TITLE
fix: Dockerfile에 gradlew 실행 권한 추가로 빌드 오류 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@
 FROM gradle:8.7.0-jdk21 AS builder
 WORKDIR /app
 
-# 빌드에 필요한 최소한의 파일만 복사
 COPY build.gradle settings.gradle gradlew gradlew.bat /app/
 COPY gradle /app/gradle
 COPY src /app/src
+
+# gradlew 실행 권한 추가
+RUN chmod +x gradlew
 
 RUN ./gradlew clean build -x test
 


### PR DESCRIPTION
## 작업 개요
- Dockerfile에 gradlew 실행 권한 추가로 빌드 오류 해결

## 상세 내용
- 

## 관련 이슈
- Closes #213 
- Related to #이슈번호

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 