### PR TITLE
ci: EC2 배포 워크플로우에 .env 주입 단계 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,17 +45,40 @@ jobs:
           source: "."
           target: "~/Team15_BE"
 
-      # EC2에서 Docker Compose 실행 (Secrets 직접 주입)
+      # EC2에서 Docker Compose 실행 (Secrets -> .env 주입)
       - name: Run Docker Compose on EC2
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_PEM_KEY }}
-          envs: SPRING_PROFILE,DB_HOST,DB_PORT,DB_NAME,DB_USER,DB_PASSWORD,DB_ROOT_PASSWORD,REDIS_HOST,REDIS_PORT,JWT_SECRET,OPENAI_API_KEY,KAKAO_CLIENT_ID,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,MAIL_USERNAME,MAIL_PASSWORD,FRONTEND_URLS
+          envs: SPRING_PROFILE,DB_HOST,DB_PORT,DB_NAME,DB_USER,DB_PASSWORD,DB_ROOT_PASSWORD,REDIS_HOST,REDIS_PORT,JWT_SECRET,OPENAI_API_KEY,KAKAO_CLIENT_ID,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,MAIL_USERNAME,MAIL_PASSWORD,FRONTEND_URLS,APP_PORT
           script: |
             cd ~/Team15_BE
+
+            echo "SPRING_PROFILE=${SPRING_PROFILE}" > .env
+            echo "DB_HOST=${DB_HOST}" >> .env
+            echo "DB_PORT=${DB_PORT}" >> .env
+            echo "DB_NAME=${DB_NAME}" >> .env
+            echo "DB_USER=${DB_USER}" >> .env
+            echo "DB_PASSWORD=${DB_PASSWORD}" >> .env
+            echo "DB_ROOT_PASSWORD=${DB_ROOT_PASSWORD}" >> .env
+            echo "REDIS_HOST=${REDIS_HOST}" >> .env
+            echo "REDIS_PORT=${REDIS_PORT}" >> .env
+            echo "JWT_SECRET=${JWT_SECRET}" >> .env
+            echo "OPENAI_API_KEY=${OPENAI_API_KEY}" >> .env
+            echo "KAKAO_CLIENT_ID=${KAKAO_CLIENT_ID}" >> .env
+            echo "KAKAO_REDIRECT_URI=${KAKAO_REDIRECT_URI}" >> .env
+            echo "GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}" >> .env
+            echo "GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}" >> .env
+            echo "GOOGLE_REDIRECT_URI=${GOOGLE_REDIRECT_URI}" >> .env
+            echo "MAIL_USERNAME=${MAIL_USERNAME}" >> .env
+            echo "MAIL_PASSWORD=${MAIL_PASSWORD}" >> .env
+            echo "FRONTEND_URLS=${FRONTEND_URLS}" >> .env
+            echo "APP_PORT=${APP_PORT}" >> .env
+
+            echo "==== GENERATED .env ===="
+            cat .env
+
             docker compose down
-            docker compose up -d --build
-
-
+            docker compose --env-file .env up -d --build


### PR DESCRIPTION
## 작업 개요
- EC2 배포 워크플로우에 .env 주입 단계 추가

## 상세 내용
- env 파일을 안 만들고 시크릿을 바로 주입해서 해보려고 했는데, 값 주입이 아예 안돼서 env 만드는 것으로 변경.

## 관련 이슈
- Closes #213 

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 