### PR TITLE
ci: EC2 배포 시 Gradle 빌드 제거 후 Docker Compose만 실행하도록 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,11 +102,12 @@ jobs:
 
             echo "===== Docker Compose Restart ====="
             docker compose down
-            docker compose --env-file .env up -d --build
+            docker compose --env-file .env.dev up -d --build
+
 
             echo "===== Container Status ====="
             docker compose ps
             docker logs --tail=50 hyuswim-app
 
             echo "===== Clean up .env ====="
-            rm -f .env
+            rm -f .env.dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,7 @@ jobs:
           source: "."
           target: "~/Team15_BE"
 
-      # EC2에서 Build + Docker Compose 실행
+      # EC2에서 Docker Compose 실행
       - name: Run Docker Compose on EC2
         uses: appleboy/ssh-action@v1.2.0
         with:
@@ -77,10 +77,6 @@ jobs:
           envs: SPRING_PROFILE,DB_HOST,DB_PORT,DB_NAME,DB_USER,DB_PASSWORD,DB_ROOT_PASSWORD,REDIS_HOST,REDIS_PORT,JWT_SECRET,OPENAI_API_KEY,KAKAO_CLIENT_ID,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,MAIL_USERNAME,MAIL_PASSWORD,FRONTEND_URLS,APP_PORT
           script: |
             cd ~/Team15_BE
-
-            echo "===== Gradle Build ====="
-            chmod +x ./gradlew
-            ./gradlew clean build -x test
 
             echo "===== Generate .env ====="
             echo "SPRING_PROFILE=${SPRING_PROFILE}" > .env

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,8 @@ out/
 .vscode/
 
 ### env ###
-.env
+.env.dev
+.env.local
 
 # MySQL local volume
 mysql-data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,10 @@ services:
     ports:
       - "${APP_PORT}:8080"
     depends_on:
-      - mysql
-      - redis
-
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_started
     environment:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILE}
       DB_HOST: ${DB_HOST}
@@ -45,6 +46,12 @@ services:
       - mysql_data:/var/lib/mysql
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     restart: always
+    healthcheck:
+      test: [ "CMD-SHELL", "mysqladmin ping -h localhost -u$DB_USER -p$DB_PASSWORD" ]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
 
   redis:
     image: redis:7.2

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,38 +1,9 @@
 spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${DB_USER}
-    password: ${DB_PASSWORD}
-
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: update   # 운영은 validate 권장
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
-
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: ${MAIL_USERNAME}
-    password: ${MAIL_PASSWORD}
-    properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
-
-jwt:
-  secret: ${JWT_SECRET}
-
-cookie:
-  secure: false
-  same-site: Lax
+        dialect: org.hibernate.dialect.MySQL8Dialect
+    show-sql: false

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,40 +1,12 @@
 spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${DB_USER}
-    password: ${DB_PASSWORD}
-
   jpa:
     hibernate:
-      ddl-auto: update  # dev 환경용, 운영은 validate 권장
+      ddl-auto: update
     properties:
       hibernate:
-        format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
         globally_quoted_identifiers: true
     show-sql: true
 
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: ${MAIL_USERNAME}
-    password: ${MAIL_PASSWORD}
-    properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
-
-jwt:
-  secret: ${JWT_SECRET}
-
-cookie:
-  secure: false
-  same-site: Lax
+  config:
+    import: optional:file:.env.${spring.profiles.active}[.properties]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,39 @@ spring:
   profiles:
     active: local
 
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+    hikari:
+      initialization-fail-timeout: 120000   # 2분
+      connection-timeout: 30000           # 커넥션 타임아웃 (30초)
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+jwt:
+  secret: ${JWT_SECRET}
+
+cookie:
+  secure: false
+  same-site: Lax
+
 openai:
   api-key: ${OPENAI_API_KEY}
 


### PR DESCRIPTION
## 작업 개요
- EC2 배포 시 Gradle 빌드 제거 후 Docker Compose만 실행하도록 수정

## 상세 내용
- EC2 배포 시 Gradle 빌드 제거 후 Docker Compose만 실행하도록 수정
- Docker Compose 환경에서 DB 연결 오류 해결]
## 관련 이슈
- Closes #213 

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 