### PR TITLE
ci: 배포 시 scp 대신 rsync 사용하여 잔여 파일 문제 해결

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# 빌드 결과물 제외
+target/
+build/
+out/
+
+# Git
+.git
+.gitignore
+
+# IDE 관련
+.idea/
+*.iws
+*.iml
+*.ipr
+
+### Logs ###
+*.log
+
+# OS 별 불필요한 파일
+.DS_Store
+Thumbs.db
+
+# 로컬 환경 변수
+.env.dev
+.env.local

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: CI/CD with Docker Hub
+name: CI/CD with Docker Compose
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  # 1. PR 빌드 검증
+  # 1. Pull Request 빌드 검증 (CI)
   build-validation:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -27,37 +27,55 @@ jobs:
       - run: chmod +x ./gradlew
       - run: ./gradlew clean build -x test
 
-  # 2. Docker 이미지 빌드 & 푸시
-  docker-build:
+  # 2. 배포 (develop 브랜치 push 시)
+  deploy:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+    env:
+      SPRING_PROFILE: ${{ secrets.SPRING_PROFILE }}
+      DB_HOST: ${{ secrets.DB_HOST }}
+      DB_PORT: ${{ secrets.DB_PORT }}
+      DB_NAME: ${{ secrets.DB_NAME }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      DB_ROOT_PASSWORD: ${{ secrets.DB_ROOT_PASSWORD }}
+      REDIS_HOST: ${{ secrets.REDIS_HOST }}
+      REDIS_PORT: ${{ secrets.REDIS_PORT }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
+      KAKAO_REDIRECT_URI: ${{ secrets.KAKAO_REDIRECT_URI }}
+      GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
+      MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+      MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+      FRONTEND_URLS: ${{ secrets.FRONTEND_URLS }}
+      APP_PORT: ${{ secrets.APP_PORT }}
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # EC2로 프로젝트 동기화 (rsync, delete 옵션)
+      - name: Sync files to EC2
+        uses: appleboy/rsync-action@v0.1.7
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_PEM_KEY }}
+          source: "./"
+          target: "~/Team15_BE"
+          delete: true   # 원격 서버에서 없는 파일은 자동 삭제
 
-      - name: Build and push Docker image
-        run: |
-          IMAGE_NAME=${{ secrets.DOCKER_HUB_USERNAME }}/hyuswim-app
-          docker build -t $IMAGE_NAME:latest .
-          docker push $IMAGE_NAME:latest
-
-  # 3. EC2에서 Docker Hub pull & 재시작
-  deploy:
-    needs: docker-build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to EC2
+      # EC2에서 Docker Compose 실행
+      - name: Run Docker Compose on EC2
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_PEM_KEY }}
-          envs: SPRING_PROFILE,DB_HOST,DB_PORT,DB_NAME,DB_USER,DB_PASSWORD,DB_ROOT_PASSWORD,REDIS_HOST,REDIS_PORT,JWT_SECRET,OPENAI_API_KEY,KAKAO_CLIENT_ID,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,MAIL_USERNAME,MAIL_PASSWORD,FRONTEND_URLS,APP_PORT,DOCKER_HUB_USERNAME
+          envs: SPRING_PROFILE,DB_HOST,DB_PORT,DB_NAME,DB_USER,DB_PASSWORD,DB_ROOT_PASSWORD,REDIS_HOST,REDIS_PORT,JWT_SECRET,OPENAI_API_KEY,KAKAO_CLIENT_ID,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,MAIL_USERNAME,MAIL_PASSWORD,FRONTEND_URLS,APP_PORT
           script: |
             cd ~/Team15_BE
 
@@ -87,8 +105,7 @@ jobs:
 
             echo "===== Docker Compose Restart ====="
             docker compose down
-            docker compose pull
-            docker compose --env-file .env up -d
+            docker compose --env-file .env up -d --build
 
             echo "===== Container Status ====="
             docker compose ps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   app:
     build: .


### PR DESCRIPTION
## 작업 개요
- 배포 시 scp 대신 rsync 사용하여 잔여 파일 문제 해결

## 상세 내용
- - scp-action→ 단순 복사라 옛날 파일이 남는데 여기서 문제가 생긴 것으로 추정됨... 변경 커밋은 한참 전이고 모든 걸 다 내렸는데도 잔여한 이유는 모르겠지만...
- rsync-action + delete:true→ 완전 동기화로 옛날 파일이 제거됨. 이 방법으로 테스트 시도.

## 관련 이슈
- Closes #213 

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 