### PR TITLE
config: 로그/DB/JSON 응답 시간대를 한국 시간으로 일괄 적용

### DIFF
--- a/src/main/java/katecam/hyuswim/HyuswimApplication.java
+++ b/src/main/java/katecam/hyuswim/HyuswimApplication.java
@@ -9,11 +9,26 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
+
 @SpringBootApplication
 @EnableJpaAuditing
-@EnableConfigurationProperties({AppProperties.class,KakaoProperties.class, GoogleProperties.class,CookieProperties.class})
+@EnableConfigurationProperties({
+        AppProperties.class,
+        KakaoProperties.class,
+        GoogleProperties.class,
+        CookieProperties.class
+})
 public class HyuswimApplication {
-  public static void main(String[] args) {
-    SpringApplication.run(HyuswimApplication.class, args);
-  }
+
+    public static void main(String[] args) {
+        SpringApplication.run(HyuswimApplication.class, args);
+    }
+
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 }
+

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,5 +7,6 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
         transaction.jta.platform: org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform
+        jdbc.time_zone: Asia/Seoul
     show-sql: false
     open-in-view: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,9 @@ spring:
           starttls:
             enable: true
 
+  jackson:
+    time-zone: Asia/Seoul
+
 jwt:
   secret: ${JWT_SECRET}
 


### PR DESCRIPTION
## 작업 개요
- 로그/DB/JSON 응답 시간대를 한국 시간으로 일괄 적용

## 상세 내용
- 

## 관련 이슈
- Closes #258 
-> 시간 문제는 에러랑은 상관없지만 미국 리전으로 서버가 열려서 시간대가 안 맞아서 로그 보기 불편함

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 