### PR TITLE
chore: mysql 메모리 튜닝으로 OOM 발생 방지

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,7 +19,12 @@ services:
       - "${DB_PORT}:3306"
     volumes:
       - mysql_data:/var/lib/mysql
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: >
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
+      --innodb-buffer-pool-size=128M
+      --innodb-log-buffer-size=16M
+      --max-connections=50
     restart: always
     healthcheck:
       test: [ "CMD-SHELL", "mysqladmin ping -h localhost -u$DB_USER -p$DB_PASSWORD" ]
@@ -30,3 +35,4 @@ services:
 
 volumes:
   mysql_data:
+


### PR DESCRIPTION
## 작업 개요
- mysql 메모리 튜닝으로 OOM 발생 방지

## 상세 내용
1. 4GB로 스왑 증설
2. mysql 메모리 튜닝
- - `-innodb-buffer-pool-size=128M` : 메모리 절반 이상 먹는 기본값 줄임
- `-innodb-log-buffer-size=16M` : 로그 버퍼 크기 줄임
- `-max-connections=50` : 연결 수 제한

## 관련 이슈
- Closes #이슈번호

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 