### PR TITLE
feat: 상담 대화 데이터 저장 방식 개선

### DIFF
--- a/src/main/java/katecam/hyuswim/counseling/service/CounselingService.java
+++ b/src/main/java/katecam/hyuswim/counseling/service/CounselingService.java
@@ -21,6 +21,7 @@ public class CounselingService {
 
     private final CounselingSessionRepository sessionRepository;
     private final OpenAiClient openAiClient;
+    private final CounselingSessionService sessionService;
     private final ObjectMapper objectMapper;
 
     private static final int MAX_TURNS = 10;
@@ -33,35 +34,57 @@ public class CounselingService {
         String greeting = openAiClient.generateCounselingReply(List.of(), CounselingStep.ACTIVE);
         String cleanGreeting = sanitizeReply(greeting);
 
-        return new CounselingResponse(session.getId(), cleanGreeting, session.getStep().name());
+        sessionService.saveMessage(session.getId(), new Message("assistant", cleanGreeting));
+        sessionService.saveStep(session.getId(), CounselingStep.ACTIVE.name());
+
+        return new CounselingResponse(session.getId(), cleanGreeting, CounselingStep.ACTIVE.name());
     }
 
     public CounselingResponse processMessage(String sessionId, String userMessage) {
         CounselingSession session = sessionRepository.findById(sessionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
 
-        List<Message> history = new ArrayList<>();
+        List<Message> history = new ArrayList<>(sessionService.getMessages(sessionId));
+
         history.add(new Message("user", userMessage));
+        sessionService.saveMessage(sessionId, new Message("user", userMessage));
+
+        long userTurns = history.stream().filter(m -> "user".equals(m.role())).count();
+        if (userTurns >= MAX_TURNS) {
+            return closeSession(session, "오늘은 충분히 얘기 나눈 것 같아, 여기서 마무리하자" + END_TOKEN);
+        }
 
         String reply = openAiClient.generateCounselingReply(history, session.getStep());
         String cleanReply = sanitizeReply(reply);
 
+        sessionService.saveMessage(sessionId, new Message("assistant", cleanReply));
+
         if (isClosingReply(reply)) {
-            session.end();
+            return closeSession(session, cleanReply);
         } else {
             session.updateStep(CounselingStep.ACTIVE);
+            sessionRepository.save(session);
+            sessionService.saveStep(sessionId, CounselingStep.ACTIVE.name());
+            return new CounselingResponse(sessionId, cleanReply, CounselingStep.ACTIVE.name());
         }
-
-        sessionRepository.save(session);
-
-        return new CounselingResponse(session.getId(), cleanReply, session.getStep().name());
     }
 
     public void endSession(String sessionId) {
         CounselingSession session = sessionRepository.findById(sessionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
+
         session.end();
         sessionRepository.save(session);
+        sessionService.endSession(sessionId);
+    }
+
+    private CounselingResponse closeSession(CounselingSession session, String closingReply) {
+        String clean = sanitizeReply(closingReply);
+        session.end();
+        sessionRepository.save(session);
+        sessionService.saveMessage(session.getId(), new Message("assistant", clean));
+        sessionService.endSession(session.getId());
+        return new CounselingResponse(session.getId(), clean, CounselingStep.CLOSED.name());
     }
 
     private boolean isClosingReply(String reply) {
@@ -72,3 +95,4 @@ public class CounselingService {
         return reply == null ? "" : reply.replace(END_TOKEN, "").trim();
     }
 }
+

--- a/src/main/java/katecam/hyuswim/counseling/service/CounselingSessionService.java
+++ b/src/main/java/katecam/hyuswim/counseling/service/CounselingSessionService.java
@@ -1,0 +1,90 @@
+package katecam.hyuswim.counseling.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import katecam.hyuswim.ai.dto.Message;
+import katecam.hyuswim.common.error.CustomException;
+import katecam.hyuswim.common.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CounselingSessionService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final String PREFIX = "session:";
+    private static final String MESSAGES_SUFFIX = ":messages";
+    private static final String STEP_SUFFIX = ":step";
+    private static final Duration TTL = Duration.ofMinutes(20);
+
+    public void saveMessage(String sessionId, Message message) {
+        String key = buildKey(sessionId, MESSAGES_SUFFIX);
+        try {
+            String json = objectMapper.writeValueAsString(message);
+            redisTemplate.opsForList().rightPush(key, json);
+            redisTemplate.expire(key, TTL);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.REDIS_OPERATION_FAILED);
+        }
+    }
+
+    public List<Message> getMessages(String sessionId) {
+        String key = buildKey(sessionId, MESSAGES_SUFFIX);
+        try {
+            List<String> jsonList = redisTemplate.opsForList().range(key, 0, -1);
+            if (jsonList == null || jsonList.isEmpty()) return List.of();
+            return jsonList.stream()
+                    .map(this::fromJson)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.REDIS_OPERATION_FAILED);
+        }
+    }
+
+    public void saveStep(String sessionId, String step) {
+        String key = buildKey(sessionId, STEP_SUFFIX);
+        try {
+            redisTemplate.opsForValue().set(key, step, TTL);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.REDIS_OPERATION_FAILED);
+        }
+    }
+
+    public String getStep(String sessionId) {
+        String key = buildKey(sessionId, STEP_SUFFIX);
+        try {
+            String step = redisTemplate.opsForValue().get(key);
+            return step != null ? step : "ACTIVE";
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.REDIS_OPERATION_FAILED);
+        }
+    }
+
+    public void endSession(String sessionId) {
+        try {
+            redisTemplate.delete(buildKey(sessionId, MESSAGES_SUFFIX));
+            redisTemplate.delete(buildKey(sessionId, STEP_SUFFIX));
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.REDIS_OPERATION_FAILED);
+        }
+    }
+
+    private String buildKey(String sessionId, String suffix) {
+        return PREFIX + sessionId + suffix;
+    }
+
+    private Message fromJson(String json) {
+        try {
+            return objectMapper.readValue(json, Message.class);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.JSON_DESERIALIZATION_FAILED);
+        }
+    }
+}


### PR DESCRIPTION
## 작업 개요
- 상담 대화 데이터 저장 방식을 개선함  
- DB에 유저 대화 내용이 저장되지 않도록 수정하고, Redis를 활용한 임시 캐싱 구조로 전환함  

## 상세 내용
- CounselingService 내부의 메시지 DB 저장 로직 제거
- Redis를 이용해 세션별 대화 메시지와 단계(step)를 캐싱하도록 CounselingSessionService 연동  
- 대화 내역은 Redis에 20분간 유지 후 자동 삭제되며, 세션 종료 시 즉시 삭제되도록 구현  

## 관련 이슈
- Closes #286 

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured counseling session management to enhance state persistence handling.
  * Updated message storage and retrieval mechanisms for counseling sessions.
  * Adjusted session initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->