### PR TITLE
fix: 좋아요 취소 후 상세조회에 반영되지 않는 문제 수정

### DIFF
--- a/src/main/java/katecam/hyuswim/like/repository/PostLikeRepository.java
+++ b/src/main/java/katecam/hyuswim/like/repository/PostLikeRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.repository.query.Param;
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
   Optional<PostLike> findByPostIdAndUserId(Long postId, Long userId);
 
-    boolean existsByUser_IdAndPost_Id(Long userId, Long postId);
+  boolean existsByUser_IdAndPost_IdAndIsDeletedFalse(Long userId, Long postId);
 
     @Query("""
         select pl.post.id

--- a/src/main/java/katecam/hyuswim/post/service/PostService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostService.java
@@ -82,7 +82,7 @@ public class PostService {
         }
 
         boolean isAuthor = post.getUser().getId().equals(currentUser.getId());
-        boolean isLiked = postLikeRepository.existsByUser_IdAndPost_Id(currentUser.getId(), post.getId());
+        boolean isLiked = postLikeRepository.existsByUser_IdAndPost_IdAndIsDeletedFalse(currentUser.getId(), post.getId());
 
         return PostDetailResponse.from(post, isAuthor, isLiked);
   }
@@ -172,7 +172,7 @@ public class PostService {
     }
 
     post.update(request.getTitle(), request.getContent(), request.getPostCategory());
-    boolean Liked = postLikeRepository.existsByUser_IdAndPost_Id(currentUser.getId(), post.getId());
+    boolean Liked = postLikeRepository.existsByUser_IdAndPost_IdAndIsDeletedFalse(currentUser.getId(), post.getId());
 
     return PostDetailResponse.from(post,true, Liked);
   }


### PR DESCRIPTION
## 작업 개요
- 좋아요 취소 후 상세조회에 반영되지 않는 문제 수정

## 상세 내용
-

## 관련 이슈
- Closes #이슈번호

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of post like status tracking by ensuring that deleted likes are properly excluded when determining if a user has actively liked a post. This affects the display of like information and processing of post updates, providing users with accurate like status across all post operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->