### PR TITLE
fix: 상세조회에서 좋아요 개수 카운트 안되던 문제 수정

### DIFF
--- a/src/main/java/katecam/hyuswim/comment/repository/CommentRepository.java
+++ b/src/main/java/katecam/hyuswim/comment/repository/CommentRepository.java
@@ -13,6 +13,14 @@ import katecam.hyuswim.comment.domain.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    @Query("""
+        select count(c)
+        from Comment c
+        where c.post.id = :postId
+          and c.isDeleted = false
+    """)
+    int countByPostIdAndIsDeletedFalse(@Param("postId") Long postId);
+
     @Query(
             value = """
                 select c

--- a/src/main/java/katecam/hyuswim/like/repository/PostLikeRepository.java
+++ b/src/main/java/katecam/hyuswim/like/repository/PostLikeRepository.java
@@ -27,8 +27,13 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     );
 
 
-    @Query("select count(pl) from PostLike pl where pl.post.id = :postId and pl.isDeleted = false")
-    int countByPostId(Long postId);
+    @Query("""
+    select count(pl)
+    from PostLike pl
+    where pl.post.id = :postId
+      and pl.isDeleted = false
+    """)
+    int countByPostIdAndIsDeletedFalse(@Param("postId") Long postId);
 
     int countByUserIdAndIsDeletedFalse(Long userId);
 

--- a/src/main/java/katecam/hyuswim/like/service/PostLikeService.java
+++ b/src/main/java/katecam/hyuswim/like/service/PostLikeService.java
@@ -49,7 +49,7 @@ public class PostLikeService {
             eventPublisher.publishEvent(new PostLikedEvent(user.getId()));
         }
 
-        int likeCount = postLikeRepository.countByPostId(postId);
+        int likeCount = postLikeRepository.countByPostIdAndIsDeletedFalse(postId);
         return new LikeToggleResponse(nowLiked, likeCount);
     }
 }

--- a/src/main/java/katecam/hyuswim/post/dto/PostDetailResponse.java
+++ b/src/main/java/katecam/hyuswim/post/dto/PostDetailResponse.java
@@ -1,55 +1,31 @@
 package katecam.hyuswim.post.dto;
 
 import java.time.LocalDateTime;
-
 import katecam.hyuswim.post.domain.Post;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class PostDetailResponse {
-  private Long id;
-  private String postCategory;
-  private String postCategoryName;
-  private String title;
-  private String content;
-  private String author;
-  private String handle;
-  private Long viewCount;
-  private Long likeCount;
-  private Long commentCount;
-  private Boolean isAuthor;
-  private Boolean isAnonymous;
-  private Boolean isLiked;
-  private LocalDateTime createdAt;
-  private LocalDateTime updatedAt;
+    private Long id;
+    private String postCategory;
+    private String postCategoryName;
+    private String title;
+    private String content;
+    private String author;
+    private String handle;
+    private Long viewCount;
+    private Long likeCount;
+    private Long commentCount;
+    private Boolean isAuthor;
+    private Boolean isAnonymous;
+    private Boolean isLiked;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
-  public static PostDetailResponse from(Post post) {
-    return PostDetailResponse.builder()
-        .id(post.getId())
-        .postCategory(post.getPostCategory().name())
-        .postCategoryName(post.getPostCategory().getDisplayName())
-        .title(post.getTitle())
-        .content(post.getContent())
-        .author(post.getUser().getDisplayName())
-        .handle(post.getUser().getHandle())
-        .likeCount((long) post.getPostLikes().size())
-        .viewCount(post.getViewCount())
-        .commentCount((long) post.getComments().size())
-        .isAuthor(false)
-        .isAnonymous(post.getIsAnonymous())
-        .isLiked(false)
-        .createdAt(post.getCreatedAt())
-        .updatedAt(post.getUpdatedAt())
-        .build();
-  }
-
-    public static PostDetailResponse from(Post post,boolean isAuthor, boolean isLiked) {
+    public static PostDetailResponse from(Post post, long likeCount, long commentCount) {
         return PostDetailResponse.builder()
                 .id(post.getId())
                 .postCategory(post.getPostCategory().name())
@@ -58,9 +34,29 @@ public class PostDetailResponse {
                 .content(post.getContent())
                 .author(post.getUser().getDisplayName())
                 .handle(post.getUser().getHandle())
-                .likeCount((long) post.getPostLikes().size())
                 .viewCount(post.getViewCount())
-                .commentCount((long) post.getComments().size())
+                .likeCount(likeCount)
+                .commentCount(commentCount)
+                .isAuthor(false)
+                .isAnonymous(post.getIsAnonymous())
+                .isLiked(false)
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    public static PostDetailResponse from(Post post, boolean isAuthor, boolean isLiked, long likeCount, long commentCount) {
+        return PostDetailResponse.builder()
+                .id(post.getId())
+                .postCategory(post.getPostCategory().name())
+                .postCategoryName(post.getPostCategory().getDisplayName())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .author(post.getUser().getDisplayName())
+                .handle(post.getUser().getHandle())
+                .viewCount(post.getViewCount())
+                .likeCount(likeCount)
+                .commentCount(commentCount)
                 .isAuthor(isAuthor)
                 .isAnonymous(post.getIsAnonymous())
                 .isLiked(isLiked)

--- a/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
+++ b/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
@@ -99,10 +99,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     );
 
     @Query("""
-    select p from Post p
+    select distinct p from Post p
     join fetch p.user u
-    left join fetch p.postLikes pl
-    left join fetch p.comments c
+    left join p.postLikes pl on pl.isDeleted = false
+    left join p.comments c on c.isDeleted = false
     where p.id = :id and p.isDeleted = false
 """)
     Optional<Post> findDetailById(@Param("id") Long id);


### PR DESCRIPTION
## 작업 개요
- 상세조회에서 좋아요 개수 카운트 안되던 문제 수정

## 상세 내용
- 

## 관련 이슈
- Closes #이슈번호
- Related to #이슈번호

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed like and comment counts on posts to correctly exclude deleted items, ensuring accurate engagement metrics display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->