### PR TITLE
feat: reids로 조회수 기능 구현

### DIFF
--- a/src/main/java/katecam/hyuswim/common/config/SchedulerConfig.java
+++ b/src/main/java/katecam/hyuswim/common/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package katecam.hyuswim.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/katecam/hyuswim/common/util/WebUtil.java
+++ b/src/main/java/katecam/hyuswim/common/util/WebUtil.java
@@ -1,0 +1,22 @@
+package katecam.hyuswim.common.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class WebUtil {
+
+    public static String getClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip != null && !ip.isBlank() && !"unknown".equalsIgnoreCase(ip)) {
+            return ip.split(",")[0].trim();
+        }
+
+        ip = request.getHeader("X-Real-IP");
+        if (ip != null && !ip.isBlank() && !"unknown".equalsIgnoreCase(ip)) {
+            return ip;
+        }
+
+        return request.getRemoteAddr();
+    }
+
+    private WebUtil() {}
+}

--- a/src/main/java/katecam/hyuswim/like/domain/PostLike.java
+++ b/src/main/java/katecam/hyuswim/like/domain/PostLike.java
@@ -33,7 +33,7 @@ public class PostLike {
     private User user;
 
     @Column(nullable = false)
-    private boolean isDeleted = false;
+    private Boolean isDeleted = false;
 
 
     @CreatedDate

--- a/src/main/java/katecam/hyuswim/like/service/PostLikeService.java
+++ b/src/main/java/katecam/hyuswim/like/service/PostLikeService.java
@@ -38,7 +38,7 @@ public class PostLikeService {
         if (existing.isPresent()) {
             PostLike like = existing.get();
             like.toggle();
-            nowLiked = !like.isDeleted();
+            nowLiked = !like.getIsDeleted();
         } else {
             postLikeRepository.save(new PostLike(post, user));
             nowLiked = true;

--- a/src/main/java/katecam/hyuswim/post/controller/PostController.java
+++ b/src/main/java/katecam/hyuswim/post/controller/PostController.java
@@ -3,6 +3,7 @@ package katecam.hyuswim.post.controller;
 import java.time.LocalDate;
 import java.util.List;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -25,12 +26,12 @@ public class PostController {
 
   private final PostService postService;
 
-  @PostMapping
-  public ResponseEntity<PostDetailResponse> createPost(
+    @PostMapping
+    public ResponseEntity<PostDetailResponse> createPost(
       @RequestBody PostRequest request, @LoginUser User currentUser) {
     PostDetailResponse response = postService.createPost(request, currentUser);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
-  }
+    }
 
     @GetMapping
     public ResponseEntity<PageResponse<PostListResponse>> getPosts(
@@ -41,14 +42,18 @@ public class PostController {
         return ResponseEntity.ok(postService.getPosts(pageable, currentUser));
     }
 
-  @GetMapping("/{id}")
-  public ResponseEntity<PostDetailResponse> getPost(@PathVariable Long id, @LoginUser User currentUser) {
-    PostDetailResponse response = postService.getPost(id,currentUser);
-    return ResponseEntity.ok(response);
-  }
+    @GetMapping("/{id}")
+    public ResponseEntity<PostDetailResponse> getPost(
+            @PathVariable Long id,
+            @LoginUser User currentUser,
+            HttpServletRequest request
+    ) {
+        PostDetailResponse response = postService.getPost(id, currentUser, request);
+        return ResponseEntity.ok(response);
+    }
 
-  @GetMapping("/search")
-  public ResponseEntity<PageResponse<PostListResponse>> searchPosts(
+    @GetMapping("/search")
+    public ResponseEntity<PageResponse<PostListResponse>> searchPosts(
       @RequestParam(required = false) String keyword,
       @RequestParam(required = false) PostCategory category,
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
@@ -60,32 +65,32 @@ public class PostController {
       @LoginUser User currentUser) {
     PostSearchRequest request = new PostSearchRequest(keyword, category, startDate, endDate);
     return ResponseEntity.ok(postService.searchPosts(request, pageable, currentUser));
-  }
+    }
 
-  @PatchMapping("/{id}")
-  public ResponseEntity<PostDetailResponse> updatePost(
+    @PatchMapping("/{id}")
+    public ResponseEntity<PostDetailResponse> updatePost(
       @PathVariable Long id, @RequestBody PostRequest request, @LoginUser User currentUser) {
     PostDetailResponse response = postService.updatePost(id, request, currentUser);
     return ResponseEntity.ok(response);
-  }
+    }
 
-  @DeleteMapping("/{id}")
-  public ResponseEntity<Void> deletePost(@PathVariable Long id, @LoginUser User currentUser) {
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePost(@PathVariable Long id, @LoginUser User currentUser) {
     postService.deletePost(id, currentUser);
     return ResponseEntity.noContent().build();
-  }
+    }
 
-  @GetMapping("/categories")
-  public ResponseEntity<List<PostCategoryResponse>> getCategories() {
+    @GetMapping("/categories")
+    public ResponseEntity<List<PostCategoryResponse>> getCategories() {
     return ResponseEntity.ok(postService.getCategories());
-  }
+    }
 
-  @GetMapping("/category/{category}")
-  public ResponseEntity<PageResponse<PostListResponse>> getPostsByCategory(
+    @GetMapping("/category/{category}")
+    public ResponseEntity<PageResponse<PostListResponse>> getPostsByCategory(
       @PathVariable PostCategory category,
       @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC, size = 10)
           Pageable pageable,
       @LoginUser User currentUser) {
     return ResponseEntity.ok(postService.getPostsByCategory(category, pageable,currentUser));
-  }
+    }
 }

--- a/src/main/java/katecam/hyuswim/post/dto/PostDetailResponse.java
+++ b/src/main/java/katecam/hyuswim/post/dto/PostDetailResponse.java
@@ -25,7 +25,7 @@ public class PostDetailResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static PostDetailResponse from(Post post, long likeCount, long commentCount) {
+    public static PostDetailResponse from(Post post, long likeCount, long commentCount, long viewCount) {
         return PostDetailResponse.builder()
                 .id(post.getId())
                 .postCategory(post.getPostCategory().name())
@@ -34,7 +34,7 @@ public class PostDetailResponse {
                 .content(post.getContent())
                 .author(post.getUser().getDisplayName())
                 .handle(post.getUser().getHandle())
-                .viewCount(post.getViewCount())
+                .viewCount(viewCount)
                 .likeCount(likeCount)
                 .commentCount(commentCount)
                 .isAuthor(false)
@@ -45,7 +45,7 @@ public class PostDetailResponse {
                 .build();
     }
 
-    public static PostDetailResponse from(Post post, boolean isAuthor, boolean isLiked, long likeCount, long commentCount) {
+    public static PostDetailResponse from(Post post, boolean isAuthor, boolean isLiked, long likeCount, long commentCount, long viewCount) {
         return PostDetailResponse.builder()
                 .id(post.getId())
                 .postCategory(post.getPostCategory().name())
@@ -54,7 +54,7 @@ public class PostDetailResponse {
                 .content(post.getContent())
                 .author(post.getUser().getDisplayName())
                 .handle(post.getUser().getHandle())
-                .viewCount(post.getViewCount())
+                .viewCount(viewCount)
                 .likeCount(likeCount)
                 .commentCount(commentCount)
                 .isAuthor(isAuthor)

--- a/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
+++ b/src/main/java/katecam/hyuswim/post/repository/PostRepository.java
@@ -8,6 +8,7 @@ import katecam.hyuswim.post.dto.PostListResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -110,6 +111,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     long countByIsDeletedFalse();
 
     long countByIsDeletedFalseAndCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Post p set p.viewCount = p.viewCount + :count where p.id = :postId")
+    void incrementViewCount(@Param("postId") Long postId, @Param("count") Long count);
 
     List<Post> findAllByUser_IdAndIsDeletedFalse(Long userId);
 }

--- a/src/main/java/katecam/hyuswim/post/service/PostService.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostService.java
@@ -1,36 +1,92 @@
 package katecam.hyuswim.post.service;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import jakarta.servlet.http.HttpServletRequest;
 
-import katecam.hyuswim.comment.repository.CommentRepository;
 import katecam.hyuswim.comment.service.CommentService;
-import katecam.hyuswim.like.repository.PostLikeRepository;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import katecam.hyuswim.common.error.CustomException;
 import katecam.hyuswim.common.error.ErrorCode;
+import katecam.hyuswim.common.util.WebUtil;
+import katecam.hyuswim.like.repository.PostLikeRepository;
 import katecam.hyuswim.post.domain.Post;
 import katecam.hyuswim.post.domain.PostCategory;
 import katecam.hyuswim.post.dto.*;
 import katecam.hyuswim.post.repository.PostRepository;
 import katecam.hyuswim.user.domain.User;
+
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class PostService {
 
+    private final RedisTemplate<String, String> redisTemplate;
     private final PostRepository postRepository;
     private final CommentService commentService;
-    private final CommentRepository commentRepository;
     private final PostLikeRepository postLikeRepository;
+
+    private PostDetailResponse buildPostDetailResponse(Post post, User currentUser, long viewCount) {
+        long likeCount = post.getPostLikes().stream().filter(l -> !l.getIsDeleted()).count();
+        long commentCount = post.getComments().stream().filter(c -> !c.getIsDeleted()).count();
+
+        boolean isAuthor = currentUser != null && post.getUser().getId().equals(currentUser.getId());
+        boolean isLiked = currentUser != null &&
+                postLikeRepository.existsByUser_IdAndPost_IdAndIsDeletedFalse(currentUser.getId(), post.getId());
+
+        return PostDetailResponse.from(post, isAuthor, isLiked, likeCount, commentCount, viewCount);
+    }
+
+    private long increaseViewCount(Long postId, User user, HttpServletRequest request) {
+        String ip = WebUtil.getClientIp(request);
+
+        String userIdentifier = (user != null)
+                ? "user:" + user.getId()
+                : "guest:" + ip;
+
+        String viewKey = "post:viewed:" + postId + ":" + userIdentifier;
+        String countKey = "post:viewCount:" + postId;
+
+        Boolean firstView = redisTemplate.opsForValue()
+                .setIfAbsent(viewKey, "1", Duration.ofHours(1));
+
+        if (Boolean.TRUE.equals(firstView)) {
+            Long newCount = redisTemplate.opsForValue().increment(countKey);
+            return newCount != null ? newCount : 0L;
+        }
+
+        String current = redisTemplate.opsForValue().get(countKey);
+        return current != null ? Long.parseLong(current) : 0L;
+    }
+
+    private static PageResponse<PostListResponse> mapPostsWithLiked(
+            Page<PostListResponse> postPage,
+            User currentUser,
+            PostLikeRepository postLikeRepository
+    ) {
+        List<Long> postIds = postPage.stream()
+                .map(PostListResponse::getId)
+                .toList();
+
+        Set<Long> likedPostIds = (currentUser == null)
+                ? Set.of()
+                : new HashSet<>(postLikeRepository.findLikedPostIdsByUserIdAndPostIds(
+                currentUser.getId(), postIds
+        ));
+
+        var mappedPage = postPage.map(
+                post -> post.withLiked(likedPostIds.contains(post.getId()))
+        );
+
+        return new PageResponse<>(mappedPage);
+    }
 
     @Transactional
     public PostDetailResponse createPost(PostRequest request, User user) {
@@ -39,62 +95,37 @@ public class PostService {
                 request.getContent(),
                 request.getPostCategory(),
                 user,
-                request.getIsAnonymous());
+                request.getIsAnonymous()
+        );
 
         Post saved = postRepository.save(post);
-
         commentService.createAiComment(saved);
 
-        long likeCount = postLikeRepository.countByPostIdAndIsDeletedFalse(post.getId());
-        long commentCount = commentRepository.countByPostIdAndIsDeletedFalse(post.getId());
-
-        return PostDetailResponse.from(saved, true, false, likeCount, commentCount);
+        return buildPostDetailResponse(saved, user, saved.getViewCount());
     }
 
     @Transactional(readOnly = true)
     public PageResponse<PostListResponse> getPosts(Pageable pageable, User currentUser) {
         var postPage = postRepository.findAllSummary(pageable);
-
-        List<Long> postIds = postPage.stream()
-                .map(PostListResponse::getId)
-                .toList();
-
-        Set<Long> likedPostIds = (currentUser == null)
-                ? Set.of()
-                : new HashSet<>(postLikeRepository.findLikedPostIdsByUserIdAndPostIds(
-                currentUser.getId(), postIds));
-
-        var postListResponses = postPage.map(
-                post -> post.withLiked(likedPostIds.contains(post.getId()))
-        );
-
-        return new PageResponse<>(postListResponses);
+        return mapPostsWithLiked(postPage, currentUser, postLikeRepository);
     }
 
     @Transactional(readOnly = true)
-    public PostDetailResponse getPost(Long id, User currentUser) {
+    public PostDetailResponse getPost(Long id, User currentUser, HttpServletRequest request) {
         Post post = postRepository.findDetailById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
-        post.increaseViewCount();
-        postRepository.save(post);
+        long redisCount = increaseViewCount(id, currentUser, request);
+        long viewCount = post.getViewCount() + redisCount;
 
-        long likeCount = postLikeRepository.countByPostIdAndIsDeletedFalse(post.getId());
-        long commentCount = commentRepository.countByPostIdAndIsDeletedFalse(post.getId());
-
-        if (currentUser == null) {
-            return PostDetailResponse.from(post, likeCount, commentCount);
-        }
-
-        boolean isAuthor = post.getUser().getId().equals(currentUser.getId());
-        boolean isLiked = postLikeRepository.existsByUser_IdAndPost_IdAndIsDeletedFalse(currentUser.getId(), post.getId());
-
-        return PostDetailResponse.from(post, isAuthor, isLiked, likeCount, commentCount);
+        return buildPostDetailResponse(post, currentUser, viewCount);
     }
 
     @Transactional(readOnly = true)
     public List<PostCategoryResponse> getCategories() {
-        return Arrays.stream(PostCategory.values()).map(PostCategoryResponse::from).toList();
+        return Arrays.stream(PostCategory.values())
+                .map(PostCategoryResponse::from)
+                .toList();
     }
 
     @Transactional(readOnly = true)
@@ -102,67 +133,25 @@ public class PostService {
             PostCategory category, Pageable pageable, User currentUser
     ) {
         var postPage = postRepository.findByCategorySummary(category, pageable);
-
-        List<Long> postIds = postPage.stream()
-                .map(PostListResponse::getId)
-                .toList();
-
-        Set<Long> likedPostIds = (currentUser == null)
-                ? Set.of()
-                : new HashSet<>(postLikeRepository.findLikedPostIdsByUserIdAndPostIds(
-                currentUser.getId(), postIds));
-
-        var responses = postPage.map(
-                post -> post.withLiked(likedPostIds.contains(post.getId()))
-        );
-
-        return new PageResponse<>(responses);
+        return mapPostsWithLiked(postPage, currentUser, postLikeRepository);
     }
 
     @Transactional(readOnly = true)
     public PageResponse<PostListResponse> searchPosts(
-            PostSearchRequest request,
-            Pageable pageable,
-            User currentUser
+            PostSearchRequest request, Pageable pageable, User currentUser
     ) {
+        String keyword = (request.getKeyword() == null || request.getKeyword().isBlank()) ? null : request.getKeyword();
 
-        String keyword = (request.getKeyword() == null || request.getKeyword().isBlank())
-                ? null
-                : request.getKeyword();
-
-        LocalDateTime startDateTime = request.getStartDate() != null
-                ? request.getStartDate().atStartOfDay()
-                : null;
-
-        LocalDateTime endDateTime = request.getEndDate() != null
+        LocalDateTime start = request.getStartDate() != null ? request.getStartDate().atStartOfDay() : null;
+        LocalDateTime end = request.getEndDate() != null
                 ? request.getEndDate().plusDays(1).atStartOfDay().minusNanos(1)
                 : null;
 
         var postPage = postRepository.searchSummary(
-                keyword,
-                request.getCategory(),
-                startDateTime,
-                endDateTime,
-                pageable
+                keyword, request.getCategory(), start, end, pageable
         );
 
-        List<Long> postIds = postPage.stream()
-                .map(PostListResponse::getId)
-                .toList();
-
-        Set<Long> likedPostIds = (currentUser == null)
-                ? Set.of()
-                : new HashSet<>(
-                postLikeRepository.findLikedPostIdsByUserIdAndPostIds(
-                        currentUser.getId(), postIds
-                )
-        );
-
-        var postListResponses = postPage.map(
-                post -> post.withLiked(likedPostIds.contains(post.getId()))
-        );
-
-        return new PageResponse<>(postListResponses);
+        return mapPostsWithLiked(postPage, currentUser, postLikeRepository);
     }
 
     @Transactional
@@ -175,26 +164,18 @@ public class PostService {
         }
 
         post.update(request.getTitle(), request.getContent(), request.getPostCategory());
-
-        boolean isLiked = postLikeRepository.existsByUser_IdAndPost_IdAndIsDeletedFalse(currentUser.getId(), post.getId());
-        long likeCount = postLikeRepository.countByPostIdAndIsDeletedFalse(post.getId());
-        long commentCount = commentRepository.countByPostIdAndIsDeletedFalse(post.getId());
-
-        return PostDetailResponse.from(post, true, isLiked, likeCount, commentCount);
+        return buildPostDetailResponse(post, currentUser, post.getViewCount());
     }
-
 
     @Transactional
-  public void deletePost(Long id, User currentUser) {
-    Post post =
-        postRepository
-            .findById(id)
-            .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+    public void deletePost(Long id, User currentUser) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
-    if (!post.getUser().getId().equals(currentUser.getId())) {
-      throw new CustomException(ErrorCode.POST_ACCESS_DENIED);
+        if (!post.getUser().getId().equals(currentUser.getId())) {
+            throw new CustomException(ErrorCode.POST_ACCESS_DENIED);
+        }
+
+        post.delete();
     }
-
-    post.delete();
-  }
 }

--- a/src/main/java/katecam/hyuswim/post/service/PostViewSyncScheduler.java
+++ b/src/main/java/katecam/hyuswim/post/service/PostViewSyncScheduler.java
@@ -1,0 +1,49 @@
+package katecam.hyuswim.post.service;
+
+import katecam.hyuswim.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PostViewSyncScheduler {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final PostRepository postRepository;
+
+    @Scheduled(fixedRate = 900_000) // 15분마다 실행
+    @Transactional
+    public void syncViewCountsToDB() {
+        Set<String> keys = redisTemplate.keys("post:viewCount:*");
+        if (keys.isEmpty()) {
+            log.info("🔁 [Scheduler] No keys found for sync.");
+            return;
+        }
+
+        for (String key : keys) {
+            try {
+                Long postId = Long.parseLong(key.split(":")[2]);
+                String countStr = redisTemplate.opsForValue().get(key);
+                log.info("🔁 [Scheduler] key={}, value={}", key, countStr);
+
+                if (countStr == null) continue;
+                Long count = Long.parseLong(countStr);
+
+                postRepository.incrementViewCount(postId, count);
+                redisTemplate.delete(key);
+
+                log.info("✅ [Scheduler] Synced postId={}, +{} views", postId, count);
+            } catch (Exception e) {
+                log.error("❌ [Scheduler] Error syncing key: {}", key, e);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## 작업 개요
- Redis 임시 저장 + 15분 주기 DB 반영 기반 조회수 관리 기능 추가

## 상세 내용
- 게시글 조회 시 Redis에 post:viewCount:{postId} 형태로 조회수 임시 저장
- 동시성 안전한 INCR 연산을 통해 경쟁 조건 방지
- PostViewSyncScheduler 추가  
  - 15분마다(`@Scheduled(fixedRate = 900_000)`) Redis → DB 반영  
  - @Transactional로 트랜잭션 보장  
  - PostRepository.incrementViewCount() JPQL Update 활용
- Redis 반영 후 키 즉시 삭제
- Redis 키가 비어 있을 경우 `No keys found for sync.` 로그 출력

## 관련 이슈
- Closes #133 

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Posts now display view counts showing how many times they have been viewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->