### PR TITLE
chore(docker): openjdk:21-jdk-slim → eclipse-temurin:21-jdk 기반으로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN chmod +x gradlew
 RUN ./gradlew clean build -x test
 
 # 2단계: 실행
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jdk
 WORKDIR /app
 
 # 로그 버퍼링 방지 및 stdout 출력 통합
@@ -23,5 +23,3 @@ COPY --from=builder /app/build/libs/*.jar app.jar
 
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]
-
-


### PR DESCRIPTION
## 작업 개요
- openjdk:21-jdk-slim → eclipse-temurin:21-jdk 기반으로 변경

## 상세 내용
- Docker Hub의 openjdk:21-jdk-slim 태그 약 2024년 하반기 이후 점진적으로 제거 
- FROM eclipse-temurin:21-jdk 로 교체

## 관련 이슈
- Closes #이슈번호

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base Docker image to ensure improved stability and ongoing maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->