### PR TITLE
chore: monitoring compose의 hyuswim-monitor 네트워크를 external:true로 변경

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -65,4 +65,4 @@ volumes:
 
 networks:
   hyuswim-monitor:
-    driver: bridge
+    external: true


### PR DESCRIPTION
## 작업 개요
- monitoring compose의 hyuswim-monitor 네트워크를 external:true로 변경

## 상세 내용
- 구체적으로 무엇을 어떻게 변경했는지 작성

## 관련 이슈
- Closes #이슈번호
- Related to #이슈번호

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated monitoring network configuration to use externally managed network. Note: The external network must be pre-configured before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->