### PR TITLE
fix: Loki 컨테이너가 Promtail 설정 파일을 참조하던 문제 수정 (config 경로 정정)

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,5 +1,7 @@
+version: '3.8'
+
 services:
-  # 컨테이너 리소스 수집
+  # 컨테이너 리소스 수집 (CPU, 메모리 등)
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:latest
     container_name: hyuswim-cadvisor
@@ -39,6 +41,33 @@ services:
     networks:
       - hyuswim-monitor
 
+  # Loki (로그 수집 저장소)
+  loki:
+    image: grafana/loki:2.9.2
+    container_name: hyuswim-loki
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki-config.yaml:/etc/loki/config.yaml
+      - ./loki-data:/loki
+    command: -config.file=/etc/loki/config.yaml
+    restart: always
+    networks:
+      - hyuswim-monitor
+
+  # Promtail (로그 수집기)
+  promtail:
+    image: grafana/promtail:2.9.2
+    container_name: hyuswim-promtail
+    volumes:
+      - /var/log:/var/log
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /etc/promtail/config.yaml:/etc/promtail/config.yaml
+    command: -config.file=/etc/promtail/config.yaml
+    restart: always
+    networks:
+      - hyuswim-monitor
+
   # Grafana (시각화)
   grafana:
     image: grafana/grafana:latest
@@ -55,41 +84,14 @@ services:
       - grafana_data:/var/lib/grafana
     depends_on:
       - prometheus
+      - loki
     restart: always
     networks:
       - hyuswim-monitor
-
-  # Loki (로그 저장소)
-  loki:
-    image: grafana/loki:2.9.2
-    container_name: hyuswim-loki
-    ports:
-      - "3100:3100"
-    command: -config.file=/etc/loki/local-config.yaml
-    volumes:
-      - ./loki-config.yaml:/etc/loki/local-config.yaml
-      - loki_data:/loki
-    networks:
-      - hyuswim-monitor
-    restart: always
-
-  # Promtail (로그 수집기)
-  promtail:
-    image: grafana/promtail:2.9.2
-    container_name: hyuswim-promtail
-    volumes:
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./promtail-config.yaml:/etc/promtail/promtail-config.yaml
-    command: -config.file=/etc/promtail/promtail-config.yaml
-    networks:
-      - hyuswim-monitor
-    restart: always
 
 volumes:
   prometheus_data:
   grafana_data:
-  loki_data:
 
 networks:
   hyuswim-monitor:


### PR DESCRIPTION
## 작업 개요
- Loki 컨테이너가 Promtail 설정 파일을 참조하던 문제 수정 (config 경로 정정)

## 상세 내용
- 구체적으로 무엇을 어떻게 변경했는지 작성

## 관련 이슈
- Closes #이슈번호
- Related to #이슈번호

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configuration to v3.8 with refined service architecture
  * Reconfigured Loki and Promtail logging services with enhanced networking and port mappings
  * Updated Grafana service dependencies to include the logging stack
  * Refined container restart policies and network connectivity settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->