### PR TITLE
chore: Loki 설정 수정 및 Prometheus 수집 주기 1시간으로 변경하여 서버 부하 최소화

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,33 +1,4 @@
-version: '3.8'
-
 services:
-  # 컨테이너 리소스 수집 (CPU, 메모리 등)
-  cadvisor:
-    image: gcr.io/cadvisor/cadvisor:latest
-    container_name: hyuswim-cadvisor
-    ports:
-      - "127.0.0.1:8081:8080"  # 내부 접근만 허용
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:rw
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-    restart: always
-    networks:
-      - hyuswim-monitor
-
-  # Redis 메트릭 수집용 Exporter
-  redis-exporter:
-    image: oliver006/redis_exporter:latest
-    container_name: hyuswim-redis-exporter
-    environment:
-      - REDIS_ADDR=redis://hyuswim-redis:6379
-    ports:
-      - "9121:9121"
-    restart: always
-    networks:
-      - hyuswim-monitor
-
   # Prometheus (메트릭 수집기)
   prometheus:
     image: prom/prometheus:latest
@@ -51,9 +22,9 @@ services:
       - ./loki-config.yaml:/etc/loki/config.yaml
       - ./loki-data:/loki
     command: -config.file=/etc/loki/config.yaml
+    restart: always
     networks:
       - hyuswim-monitor
-    restart: always
 
   # Promtail (로그 수집기)
   promtail:
@@ -64,9 +35,9 @@ services:
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - ./promtail-config.yaml:/etc/promtail/config.yaml
     command: -config.file=/etc/promtail/config.yaml
+    restart: always
     networks:
       - hyuswim-monitor
-    restart: always
 
   # Grafana (시각화)
   grafana:

--- a/monitoring/loki-config.yaml
+++ b/monitoring/loki-config.yaml
@@ -8,8 +8,7 @@ common:
   path_prefix: /loki
   storage:
     filesystem:
-      chunks_directory: /loki/chunks
-      rules_directory: /loki/rules
+      directory: /loki/data
   replication_factor: 1
   ring:
     instance_addr: 127.0.0.1
@@ -28,13 +27,8 @@ schema_config:
 
 storage_config:
   filesystem:
-    chunks_directory: /loki/chunks
-    rules_directory: /loki/rules
+    directory: /loki/data
 
 limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
-
-compactor:
-  working_directory: /loki/compactor
-  shared_store: filesystem

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,20 +1,17 @@
 global:
-  scrape_interval: 5s
-  evaluation_interval: 5s
+  scrape_interval: 1h
+  evaluation_interval: 1h
 
 scrape_configs:
-  # Spring Boot (Actuator)
   - job_name: 'hyuswim-app'
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets: ['hyuswim-app:8080']
 
-  # Redis Exporter
   - job_name: 'hyuswim-redis'
     static_configs:
       - targets: ['hyuswim-redis-exporter:9121']
 
-  # cAdvisor (Docker metrics)
   - job_name: 'hyuswim-cadvisor'
     static_configs:
       - targets: ['hyuswim-cadvisor:8080']

--- a/monitoring/promtail-config.yaml
+++ b/monitoring/promtail-config.yaml
@@ -15,4 +15,4 @@ scrape_configs:
           - localhost
         labels:
           job: docker
-          __path__: /var/lib/docker/containers/*/*.log
+          __path__: /var/lib/docker/containers/hyuswim-app*/**.log


### PR DESCRIPTION
## 작업 개요
- Loki 설정 수정 및 Prometheus 수집 주기 1시간으로 변경하여 서버 부하 최소화

## 상세 내용
- 구체적으로 무엇을 어떻게 변경했는지 작성

## 관련 이슈
- Closes #이슈번호
- Related to #이슈번호

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed two monitoring services from the stack
  * Added automatic restart policies for core monitoring services
  * Updated monitoring collection intervals from 5 seconds to 1 hour
  * Narrowed log collection scope to specific containers
  * Simplified storage configuration for log management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->