### PR TITLE
fix: 내프로필 조회 api에 points 필드값이 안들어가는 버그 수정

### DIFF
--- a/src/main/java/katecam/hyuswim/user/service/MyPageService.java
+++ b/src/main/java/katecam/hyuswim/user/service/MyPageService.java
@@ -163,6 +163,7 @@ public class MyPageService {
               .lastActiveDate(loginUser.getLastActiveDate())
               .score(loginUser.getScore())
               .level(loginUser.getLevel())
+              .points(loginUser.getPoints())
               .build();
   }
 


### PR DESCRIPTION
## 작업 개요
- 내 프로필 조회 api에 points값이 제대로 들어가게 변경

## 상세 내용
- dto를 만들때 같이넣는것을 깜빡함

## 관련 이슈
- Closes #이슈번호
- Related to #이슈번호

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User profile now displays accumulated points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->