### PR TITLE
fix: 회원가입시 알림여부에 null값이 들어가서 500에러뜨는걸 수정

### DIFF
--- a/src/main/java/katecam/hyuswim/user/domain/User.java
+++ b/src/main/java/katecam/hyuswim/user/domain/User.java
@@ -93,6 +93,8 @@ public class User {
         this.introduction = introduction;
         this.role = role;
         this.handle = "@" + generateHandle();
+        this.commentNotificationEnabled = true;
+        this.likeNotificationEnabled = true;
     }
 
     public void delete() {


### PR DESCRIPTION
## 작업 개요
- 회원가입시 알림여부에 null값이 들어가서 500에러뜨는걸 수정

## 상세 내용
- User 생성자에 알림여부 true들어가게 수정

## 관련 이슈
- Closes #이슈번호
- Related to #이슈번호

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code adjustments to notification settings initialization.

*Note: No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->