### PR TITLE
fix: 카카오 url 롤백

### DIFF
--- a/src/main/java/katecam/hyuswim/auth/controller/KakaoAuthController.java
+++ b/src/main/java/katecam/hyuswim/auth/controller/KakaoAuthController.java
@@ -26,10 +26,11 @@ public class KakaoAuthController {
     private final KakaoAuthService kakaoAuthService;
 
     @GetMapping("/url")
-    public void redirectToKakao(HttpServletResponse response) throws IOException {
+    public ResponseEntity<String> getKakaoLoginUrl() {
         String kakaoUrl = kakaoAuthService.generateLoginUrl();
-        response.sendRedirect(kakaoUrl);
+        return ResponseEntity.ok(kakaoUrl);
     }
+
 
     @GetMapping("/callback")
     public void kakaoCallback(@RequestParam("code") String code, HttpServletResponse response) throws IOException {


### PR DESCRIPTION
## 작업 개요
- 카카오 url 롤백

## 상세 내용
- 구체적으로 무엇을 어떻게 변경했는지 작성

## 관련 이슈
- Closes #이슈번호
- Related to #이슈번호

## 테스트 방법
- [ ] 로컬 서버 실행 후 API 호출 결과 확인
- [ ] 요청/응답 상태코드 및 응답 데이터 확인

## 체크리스트
- [ ] 빌드 및 테스트 통과
- [ ] 코드 컨벤션 준수
- [ ] 리뷰어가 이해할 수 있도록 설명 작성
- [ ] 관련 문서/주석 업데이트

## 리뷰 중점 사항
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * The Kakao authentication URL endpoint now returns the login URL in the response body instead of issuing an automatic server-side redirect. This change provides more flexibility for client-side authentication flow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->